### PR TITLE
Fix QR code validation error

### DIFF
--- a/app/controller/AsistenciaController.php
+++ b/app/controller/AsistenciaController.php
@@ -69,8 +69,9 @@ class AsistenciaController extends Controller
 			echo json_encode(['exito' => false, 'mensaje' => 'Método no permitido.']);
 			return;
 		}
-		$token_acceso = $_POST['token_acceso'] ?? '';
-		$token_dinamico = $_POST['token_dinamico'] ?? '';
+               $token_acceso = $_POST['token_acceso'] ?? '';
+               $token_dinamico = $_POST['token_dinamico'] ?? '';
+               $token_dinamico = strtoupper(trim($token_dinamico));
 		$latitud_asistente = $_POST['latitud'] ?? null;
 		$longitud_asistente = $_POST['longitud'] ?? null;
 		$invitacion = $this->invitacionModel->obtenerPorToken($token_acceso);

--- a/app/model/TokenAsistenciaModel.php
+++ b/app/model/TokenAsistenciaModel.php
@@ -23,20 +23,22 @@ class TokenAsistenciaModel extends Model
 	/**
 	 * Valida un token dinámico, comprobando que exista y no haya expirado.
 	 */
-	public function validarToken($id_evento, $token_dinamico)
-	{
-		$sql = "SELECT id FROM tokens_asistencia_dinamicos 
-                WHERE id_evento = :id_evento 
-                AND token_dinamico = :token_dinamico 
-                AND fecha_expiracion > NOW()";
-		try {
-			$stmt = $this->db->prepare($sql);
-			$stmt->bindParam(':id_evento', $id_evento);
-			$stmt->bindParam(':token_dinamico', $token_dinamico);
-			$stmt->execute();
-			return $stmt->rowCount() > 0;
-		} catch (PDOException $e) {
-			return false;
-		}
-	}
+       public function validarToken($id_evento, $token_dinamico)
+       {
+               $token_dinamico = strtoupper(trim($token_dinamico));
+
+               $sql = "SELECT id FROM tokens_asistencia_dinamicos
+               WHERE id_evento = :id_evento
+               AND token_dinamico = :token_dinamico
+               AND fecha_expiracion > NOW()";
+               try {
+                       $stmt = $this->db->prepare($sql);
+                       $stmt->bindParam(':id_evento', $id_evento);
+                       $stmt->bindParam(':token_dinamico', $token_dinamico);
+                       $stmt->execute();
+                       return $stmt->rowCount() > 0;
+               } catch (PDOException $e) {
+                       return false;
+               }
+       }
 }


### PR DESCRIPTION
## Summary
- sanitize token_dinamico in AsistenciaController
- sanitize token in TokenAsistenciaModel

## Testing
- `php -l app/controller/AsistenciaController.php`
- `php -l app/model/TokenAsistenciaModel.php`


------
https://chatgpt.com/codex/tasks/task_e_687708f61234832c936ca6962743a285