### PR TITLE
Fix QR expiry issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # vocatorid
-vocatorid
+
+Este proyecto gestiona eventos y el registro de asistencia mediante códigos QR.
+
+Para los organizadores existe una guía con pasos a seguir cuando el kiosco muestra que el código QR es inválido o ha expirado. Puedes consultarla en [docs/guia_manejo_error_qr.md](docs/guia_manejo_error_qr.md).

--- a/app/controller/AsistenciaController.php
+++ b/app/controller/AsistenciaController.php
@@ -89,10 +89,12 @@ class AsistenciaController extends Controller
 			echo json_encode(['exito' => false, 'mensaje' => 'El evento asociado no se pudo encontrar.']);
 			return;
 		}
-		if (!$this->tokenAsistenciaModel->validarToken($evento->id, $token_dinamico)) {
-			echo json_encode(['exito' => false, 'mensaje' => 'El código QR es incorrecto o ha expirado.']);
-			return;
-		}
+                if (!$this->tokenAsistenciaModel->validarToken($evento->id, $token_dinamico)) {
+                        $mensaje = 'El código QR ya no es válido o no corresponde al evento. '
+                                . 'Obtén un nuevo código desde el kiosco y vuelve a intentarlo.';
+                        echo json_encode(['exito' => false, 'mensaje' => $mensaje]);
+                        return;
+                }
 		if ($evento->modo !== 'Virtual') {
 			if (is_null($latitud_asistente) || is_null($longitud_asistente)) {
 				echo json_encode(['exito' => false, 'mensaje' => 'No se pudo obtener tu ubicación GPS.']);

--- a/app/controller/EventoController.php
+++ b/app/controller/EventoController.php
@@ -235,7 +235,11 @@ class EventoController extends Controller
 	{
 		header('Content-Type: application/json');
 		$token_dinamico = strtoupper(substr(bin2hex(random_bytes(4)), 0, 6));
-		$expiracion_segundos = 15;
+                // El token se actualiza periódicamente en el kiosco y antes
+                // expiraba a los 15 segundos, lo que resultaba demasiado
+                // estricto para algunos asistentes. Ahora otorgamos un margen
+                // mayor de tiempo para que puedan escanearlo con calma.
+                $expiracion_segundos = 120; // 2 minutos de validez
 		$fecha_expiracion = (new DateTime())->add(new DateInterval("PT{$expiracion_segundos}S"))->format('Y-m-d H:i:s');
 
 		if ($this->tokenAsistenciaModel->crear($id_evento, $token_dinamico, $fecha_expiracion)) {

--- a/docs/guia_manejo_error_qr.md
+++ b/docs/guia_manejo_error_qr.md
@@ -1,0 +1,11 @@
+# Guía para el organizador
+
+Cuando alguien intenta registrar su asistencia y aparece el mensaje “El código QR ya no es válido o no corresponde al evento. Obtén un nuevo código desde el kiosco y vuelve a intentarlo.” sigue estos pasos:
+
+1. **Generar un nuevo QR**: en el kiosco presiona el botón “Actualizar código” para crear un nuevo token.
+2. **Verificar la hora del kiosco**: asegúrate de que el reloj del dispositivo sea correcto para evitar expiraciones adelantadas.
+3. **Probar con otro dispositivo**: si el problema persiste, intenta escanear desde un teléfono diferente para descartar problemas de cámara.
+4. **Consultar el registro de tokens**: revisa en la sección de administración que la generación y validación de tokens no tenga fallas.
+5. **Contactar soporte**: si después de intentar lo anterior la persona no puede registrarse, informa al equipo de soporte para que analice el evento y el token.
+
+Recuerda que cada código QR tiene una validez aproximada de dos minutos, por lo que es normal que caduque si pasa demasiado tiempo entre que se genera y se escanea.


### PR DESCRIPTION
## Summary
- increase QR token validity window to 2 minutes so scanning has a better chance of succeeding
- clarify the error message when an expired or mismatched QR code is scanned
- add guide for organizers on handling QR-related issues

## Testing
- `php -l app/controller/EventoController.php`
- `php -l app/controller/AsistenciaController.php`


------
https://chatgpt.com/codex/tasks/task_e_687d2bd93930832cb0f502e4730bc208