### PR TITLE
Integrate dynamic challenge attendance

### DIFF
--- a/app/controller/AsistenciaController.php
+++ b/app/controller/AsistenciaController.php
@@ -8,20 +8,22 @@ class AsistenciaController extends Controller
 
 	private $invitacionModel;
 	private $eventoModel;
-	private $registroAsistenciaModel;
-	private $tokenAsistenciaModel;
-	private $contactoModel;
-	private $mailService;
+        private $registroAsistenciaModel;
+        private $tokenAsistenciaModel;
+        private $contactoModel;
+        private $retoModel;
+        private $mailService;
 
-	public function __construct()
-	{
-		$this->invitacionModel = $this->modelo('InvitacionModel');
-		$this->eventoModel = $this->modelo('EventoModel');
-		$this->registroAsistenciaModel = $this->modelo('RegistroAsistenciaModel');
-		$this->tokenAsistenciaModel = $this->modelo('TokenAsistenciaModel');
-		$this->contactoModel = $this->modelo('ContactoModel');
-		$this->mailService = new BrevoMailService();
-	}
+        public function __construct()
+        {
+                $this->invitacionModel = $this->modelo('InvitacionModel');
+                $this->eventoModel = $this->modelo('EventoModel');
+                $this->registroAsistenciaModel = $this->modelo('RegistroAsistenciaModel');
+                $this->tokenAsistenciaModel = $this->modelo('TokenAsistenciaModel');
+                $this->contactoModel = $this->modelo('ContactoModel');
+                $this->retoModel = $this->modelo('RetoModel');
+                $this->mailService = new BrevoMailService();
+        }
 
 	public function bienvenida($token_acceso = '')
 	{
@@ -266,9 +268,9 @@ class AsistenciaController extends Controller
 		$this->vista('asistencia/registro_anonimo', $datos);
 	}
 
-	public function procesarRegistroAnonimo()
-	{
-		if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+        public function procesarRegistroAnonimo()
+        {
+                if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			$id_evento = $_POST['id_evento'];
 			$nombre = trim($_POST['nombre']);
 			$email = trim($_POST['email']);
@@ -317,9 +319,65 @@ class AsistenciaController extends Controller
 				die('Hubo un error al registrar el contacto. Es posible que el correo ya esté en uso.');
 			}
 		} else {
-			$this->redireccionar('');
-		}
-	}
+                        $this->redireccionar('');
+                }
+        }
+
+        /**
+         * Nueva ruta: /asistencia/{token}
+         * Muestra la interfaz de verificación con retos dinámicos.
+         */
+        public function accesoDirecto($token_acceso = '')
+        {
+                if (empty($token_acceso)) {
+                        die('Acceso denegado: Token no proporcionado.');
+                }
+                $invitacion = $this->invitacionModel->obtenerPorToken($token_acceso);
+                if (!$invitacion) {
+                        die('Enlace de invitación no válido o caducado.');
+                }
+                $datos = ['titulo' => 'Verificación de Asistencia', 'invitacion' => $invitacion];
+                $this->vista('asistencia/reto', $datos);
+        }
+
+        public function obtenerReto($token_acceso = '')
+        {
+                header('Content-Type: application/json');
+                $invitacion = $this->invitacionModel->obtenerPorToken($token_acceso);
+                if (!$invitacion) {
+                        echo json_encode(['exito' => false]);
+                        return;
+                }
+                $reto = $this->retoModel->obtenerActivoPorEvento($invitacion->id_evento);
+                if (!$reto) {
+                        echo json_encode(['exito' => false]);
+                        return;
+                }
+                $codigo = strtoupper(substr(bin2hex(random_bytes(3)), 0, 6));
+                $this->retoModel->actualizarCodigo($reto->id, $codigo);
+                echo json_encode(['exito' => true, 'id_reto' => $reto->id, 'codigo' => $codigo]);
+        }
+
+        public function validarReto()
+        {
+                header('Content-Type: application/json');
+                $token = $_POST['token'] ?? '';
+                $id_reto = $_POST['id_reto'] ?? 0;
+                $codigo = strtoupper(trim($_POST['codigo'] ?? ''));
+
+                $invitacion = $this->invitacionModel->obtenerPorToken($token);
+                if (!$invitacion) {
+                        echo json_encode(['exito' => false, 'mensaje' => 'Invitación no válida']);
+                        return;
+                }
+                if (!$this->retoModel->validarCodigo($id_reto, $codigo)) {
+                        echo json_encode(['exito' => false, 'mensaje' => 'Código incorrecto o expirado']);
+                        return;
+                }
+                $ip = $_SERVER['REMOTE_ADDR'] ?? '';
+                $this->registroAsistenciaModel->registrarReto($invitacion->id, $id_reto, $ip, $codigo);
+                echo json_encode(['exito' => true, 'mensaje' => 'Verificación registrada']);
+        }
 
 	private function crearMensaje($tipo, $mensaje)
 	{

--- a/app/model/RegistroAsistenciaModel.php
+++ b/app/model/RegistroAsistenciaModel.php
@@ -6,18 +6,36 @@ class RegistroAsistenciaModel extends Model
 	/**
 	 * Crea el registro final de asistencia para una invitación.
 	 */
-	public function crear($id_invitacion, $coordenadas_checkin = null)
-	{
+        public function crear($id_invitacion, $coordenadas_checkin = null)
+        {
 		$sql = "INSERT INTO registros_asistencia (id_invitacion, coordenadas_checkin) VALUES (:id_invitacion, :coordenadas_checkin)";
-		try {
-			$stmt = $this->db->prepare($sql);
-			$stmt->bindParam(':id_invitacion', $id_invitacion);
-			$stmt->bindParam(':coordenadas_checkin', $coordenadas_checkin);
-			return $stmt->execute();
-		} catch (PDOException $e) {
-			return false;
-		}
-	}
+                try {
+                        $stmt = $this->db->prepare($sql);
+                        $stmt->bindParam(':id_invitacion', $id_invitacion);
+                        $stmt->bindParam(':coordenadas_checkin', $coordenadas_checkin);
+                        return $stmt->execute();
+                } catch (PDOException $e) {
+                        return false;
+                }
+        }
+
+        /**
+         * Registra la respuesta de un reto de verificación.
+         */
+        public function registrarReto($id_invitacion, $id_reto, $ip_origen, $codigo_utilizado)
+        {
+                $sql = "INSERT INTO registros_asistencia (id_invitacion, id_reto, ip_origen, token_utilizado) VALUES (:id_invitacion, :id_reto, :ip_origen, :token_utilizado)";
+                try {
+                        $stmt = $this->db->prepare($sql);
+                        $stmt->bindParam(':id_invitacion', $id_invitacion);
+                        $stmt->bindParam(':id_reto', $id_reto);
+                        $stmt->bindParam(':ip_origen', $ip_origen);
+                        $stmt->bindParam(':token_utilizado', $codigo_utilizado);
+                        return $stmt->execute();
+                } catch (PDOException $e) {
+                        return false;
+                }
+        }
 
 	/**
 	 * Verifica si ya existe un registro de asistencia para una invitación.

--- a/app/model/RetoModel.php
+++ b/app/model/RetoModel.php
@@ -1,0 +1,78 @@
+<?php
+
+class RetoModel extends Model
+{
+    public function crear($datos)
+    {
+        $sql = "INSERT INTO retos (id_evento, descripcion, hora_inicio, hora_fin, codigo_actual, fecha_creacion)
+                VALUES (:id_evento, :descripcion, :hora_inicio, :hora_fin, :codigo_actual, NOW())";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':id_evento', $datos['id_evento']);
+            $stmt->bindParam(':descripcion', $datos['descripcion']);
+            $stmt->bindParam(':hora_inicio', $datos['hora_inicio']);
+            $stmt->bindParam(':hora_fin', $datos['hora_fin']);
+            $stmt->bindParam(':codigo_actual', $datos['codigo_actual']);
+            if ($stmt->execute()) {
+                return $this->db->lastInsertId();
+            }
+            return false;
+        } catch (PDOException $e) {
+            return false;
+        }
+    }
+
+    public function obtenerActivoPorEvento($id_evento)
+    {
+        $sql = "SELECT * FROM retos WHERE id_evento = :id_evento AND hora_inicio <= NOW() AND hora_fin >= NOW() ORDER BY hora_inicio DESC LIMIT 1";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':id_evento', $id_evento);
+            $stmt->execute();
+            return $stmt->fetch(PDO::FETCH_OBJ);
+        } catch (PDOException $e) {
+            return false;
+        }
+    }
+
+    public function actualizarCodigo($id_reto, $codigo)
+    {
+        $sql = "UPDATE retos SET codigo_actual = :codigo WHERE id = :id_reto";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':codigo', $codigo);
+            $stmt->bindParam(':id_reto', $id_reto);
+            return $stmt->execute();
+        } catch (PDOException $e) {
+            return false;
+        }
+    }
+
+    public function obtenerPorId($id_reto)
+    {
+        $sql = "SELECT * FROM retos WHERE id = :id_reto";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':id_reto', $id_reto);
+            $stmt->execute();
+            return $stmt->fetch(PDO::FETCH_OBJ);
+        } catch (PDOException $e) {
+            return false;
+        }
+    }
+
+    public function validarCodigo($id_reto, $codigo)
+    {
+        $sql = "SELECT id FROM retos WHERE id = :id_reto AND codigo_actual = :codigo AND hora_inicio <= NOW() AND hora_fin >= NOW()";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':id_reto', $id_reto);
+            $stmt->bindParam(':codigo', $codigo);
+            $stmt->execute();
+            return $stmt->rowCount() > 0;
+        } catch (PDOException $e) {
+            return false;
+        }
+    }
+}
+?>

--- a/app/views/asistencia/reto.php
+++ b/app/views/asistencia/reto.php
@@ -1,0 +1,43 @@
+<?php
+$invitacion = $datos['invitacion'];
+?>
+<div class="container container-main d-flex align-items-center">
+    <div class="w-100" style="max-width:500px;margin:auto;">
+        <h1 class="h2 text-center mb-4">Verificación de Asistencia</h1>
+        <div class="text-center mb-3">
+            <div id="codigo-reto" class="display-4 fw-bold">----</div>
+        </div>
+        <input type="text" id="respuesta" class="form-control text-center mb-3" placeholder="Ingresa el código">
+        <button id="btn-verificar" class="btn btn-primary w-100 mb-2">Verificar</button>
+        <button id="btn-nuevo" class="btn btn-outline-secondary w-100">Generar Nuevo Reto</button>
+        <div id="mensaje" class="mt-3 text-center"></div>
+    </div>
+</div>
+<script>
+const token = '<?php echo $invitacion->token_acceso; ?>';
+let idReto = null;
+async function generarReto(){
+    const resp = await fetch('<?php echo URL_PATH; ?>asistencia/obtenerReto/' + token);
+    const data = await resp.json();
+    if(data.exito){
+        idReto = data.id_reto;
+        document.getElementById('codigo-reto').textContent = data.codigo;
+        setTimeout(generarReto, 15000);
+    }else{
+        document.getElementById('codigo-reto').textContent = '----';
+    }
+}
+async function verificar(){
+    const codigo = document.getElementById('respuesta').value;
+    const formData = new FormData();
+    formData.append('token', token);
+    formData.append('id_reto', idReto);
+    formData.append('codigo', codigo);
+    const resp = await fetch('<?php echo URL_PATH; ?>asistencia/validarReto', {method:'POST', body:formData});
+    const data = await resp.json();
+    document.getElementById('mensaje').textContent = data.mensaje;
+}
+document.getElementById('btn-nuevo').addEventListener('click', generarReto);
+document.getElementById('btn-verificar').addEventListener('click', verificar);
+generarReto();
+</script>

--- a/index.php
+++ b/index.php
@@ -16,6 +16,14 @@ $controllerName = $router->getController();
 $methodName = $router->getMethod();
 $params = $router->getParams();
 
+if ($controllerName === 'asistencia') {
+        $permitidos = ['bienvenida','iniciarVerificacion','mostrarDesafio','procesarClaveVisual','registroAnonimo','procesarRegistroAnonimo','procesarVerificacion','procesarQrPersonal','accesoDirecto','obtenerReto','validarReto'];
+        if (!in_array($methodName, $permitidos)) {
+                $params = [$methodName];
+                $methodName = 'accesoDirecto';
+        }
+}
+
 // --- LISTA BLANCA ACTUALIZADA ---
 $rutas_publicas = [
 	// Controlador 'organizador'
@@ -33,12 +41,15 @@ $rutas_publicas = [
 	// Controlador 'asistencia'
 	'asistencia/bienvenida',
 	'asistencia/iniciarVerificacion',     // <-- RUTA AÑADIDA: Permite el acceso a la página del escáner.
-	'asistencia/mostrarDesafio',         // <-- RUTA AÑADIDA: Permite el acceso a la verificación con clave visual.
-	'asistencia/procesarClaveVisual',    // <-- RUTA AÑADIDA: Permite el envío del formulario de la clave visual.
-	'asistencia/registroAnonimo',
-	'asistencia/procesarRegistroAnonimo',
-	'asistencia/procesarVerificacion', // API para kiosco virtual
-	'asistencia/procesarQrPersonal', // API para kiosco físico
+        'asistencia/mostrarDesafio',         // <-- RUTA AÑADIDA: Permite el acceso a la verificación con clave visual.
+        'asistencia/procesarClaveVisual',    // <-- RUTA AÑADIDA: Permite el envío del formulario de la clave visual.
+        'asistencia/registroAnonimo',
+        'asistencia/procesarRegistroAnonimo',
+        'asistencia/procesarVerificacion', // API para kiosco virtual
+        'asistencia/procesarQrPersonal', // API para kiosco físico
+        'asistencia/accesoDirecto',
+        'asistencia/obtenerReto',
+        'asistencia/validarReto',
 
 	// Controlador 'invitacion'
 	'invitacion/responder'


### PR DESCRIPTION
## Summary
- create `RetoModel` for new dynamic challenges
- extend attendance controller with challenge-based flow
- handle `/asistencia/[token]` links in router
- log challenge responses
- add simple verification view

## Testing
- `php -l app/model/RetoModel.php`
- `php -l app/controller/AsistenciaController.php`
- `php -l app/model/RegistroAsistenciaModel.php`
- `php -l index.php`
- `php -l app/views/asistencia/reto.php`


------
https://chatgpt.com/codex/tasks/task_e_68895175c378832cb6fdf273a2c57455