### PR TITLE
Add dynamic challenge verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # vocatorid
 
-Este proyecto gestiona eventos y el registro de asistencia mediante códigos QR.
+Este proyecto gestiona eventos y el registro de asistencia. Originalmente se basaba en códigos QR,
+pero ahora incluye un sistema de verificación mediante retos dinámicos para eventos virtuales.
 
 Para los organizadores existe una guía con pasos a seguir cuando el kiosco muestra que el código QR es inválido o ha expirado. Puedes consultarla en [docs/guia_manejo_error_qr.md](docs/guia_manejo_error_qr.md).

--- a/app/model/RegistroRetoModel.php
+++ b/app/model/RegistroRetoModel.php
@@ -1,0 +1,49 @@
+<?php
+class RegistroRetoModel extends Model
+{
+    public function crear($id_reto, $id_invitacion, $codigo_ingresado, $ip, $correcto)
+    {
+        $sql = "INSERT INTO registros_retos (id_reto, id_invitacion, codigo_ingresado, ip, correcto, fecha_registro) VALUES (:id_reto, :id_invitacion, :codigo_ingresado, :ip, :correcto, NOW())";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':id_reto', $id_reto, PDO::PARAM_INT);
+            $stmt->bindParam(':id_invitacion', $id_invitacion, PDO::PARAM_INT);
+            $stmt->bindParam(':codigo_ingresado', $codigo_ingresado);
+            $stmt->bindParam(':ip', $ip);
+            $stmt->bindParam(':correcto', $correcto, PDO::PARAM_INT);
+            return $stmt->execute();
+        } catch (PDOException $e) {
+            return false;
+        }
+    }
+
+    public function obtenerPorReto($id_reto)
+    {
+        $sql = "SELECT * FROM registros_retos WHERE id_reto = :id_reto";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':id_reto', $id_reto, PDO::PARAM_INT);
+            $stmt->execute();
+            return $stmt->fetchAll(PDO::FETCH_OBJ);
+        } catch (PDOException $e) {
+            return [];
+        }
+    }
+
+    public function obtenerPorEvento($id_evento)
+    {
+        $sql = "SELECT rr.*, c.nombre FROM registros_retos rr
+                JOIN invitaciones i ON rr.id_invitacion = i.id
+                JOIN contactos c ON i.id_contacto = c.id
+                WHERE i.id_evento = :id_evento";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':id_evento', $id_evento, PDO::PARAM_INT);
+            $stmt->execute();
+            return $stmt->fetchAll(PDO::FETCH_OBJ);
+        } catch (PDOException $e) {
+            return [];
+        }
+    }
+}
+?>

--- a/app/model/RetoModel.php
+++ b/app/model/RetoModel.php
@@ -1,0 +1,48 @@
+<?php
+class RetoModel extends Model
+{
+    public function crear($id_evento, $descripcion, $hora_inicio, $hora_fin)
+    {
+        $sql = "INSERT INTO retos (id_evento, descripcion, hora_inicio, hora_fin, fecha_creacion) VALUES (:id_evento, :descripcion, :hora_inicio, :hora_fin, NOW())";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':id_evento', $id_evento, PDO::PARAM_INT);
+            $stmt->bindParam(':descripcion', $descripcion);
+            $stmt->bindParam(':hora_inicio', $hora_inicio);
+            $stmt->bindParam(':hora_fin', $hora_fin);
+            if ($stmt->execute()) {
+                return $this->db->lastInsertId();
+            }
+            return false;
+        } catch (PDOException $e) {
+            return false;
+        }
+    }
+
+    public function actualizarCodigo($id_reto, $codigo_actual)
+    {
+        $sql = "UPDATE retos SET codigo_actual = :codigo_actual WHERE id = :id_reto";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':codigo_actual', $codigo_actual);
+            $stmt->bindParam(':id_reto', $id_reto, PDO::PARAM_INT);
+            return $stmt->execute();
+        } catch (PDOException $e) {
+            return false;
+        }
+    }
+
+    public function obtenerActivoPorEvento($id_evento)
+    {
+        $sql = "SELECT * FROM retos WHERE id_evento = :id_evento AND hora_inicio <= NOW() AND hora_fin >= NOW() ORDER BY id DESC LIMIT 1";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':id_evento', $id_evento, PDO::PARAM_INT);
+            $stmt->execute();
+            return $stmt->fetch(PDO::FETCH_OBJ);
+        } catch (PDOException $e) {
+            return false;
+        }
+    }
+}
+?>

--- a/app/views/asistencia/espera_reto.php
+++ b/app/views/asistencia/espera_reto.php
@@ -1,0 +1,61 @@
+<?php
+$evento = $datos['evento'];
+$invitacion = $datos['invitacion'];
+?>
+<div class="container container-main d-flex align-items-center">
+    <div class="w-100" style="max-width: 600px; margin:auto;">
+        <div class="text-center mb-4">
+            <h1 class="h2 mb-3">Verificación de Asistencia</h1>
+            <p class="lead text-muted">Ingresa el código que se muestra en pantalla.</p>
+        </div>
+        <div class="card shadow-sm">
+            <div class="card-body text-center" id="reto-container">
+                <h3 id="codigo-reto" class="display-4">---</h3>
+                <div class="mb-3">
+                    <input type="text" id="respuesta" class="form-control text-center" placeholder="Código" maxlength="6">
+                </div>
+                <div class="d-grid gap-2">
+                    <button id="btn-verificar" class="btn btn-primary">Verificar</button>
+                    <button id="btn-nuevo" class="btn btn-outline-secondary">Generar Nuevo Reto</button>
+                </div>
+                <div id="mensaje" class="mt-3"></div>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+const token = '<?php echo $invitacion->token_acceso; ?>';
+let idReto = 0;
+
+async function cargarReto() {
+    const res = await fetch('<?php echo URL_PATH; ?>asistencia/obtenerRetoActivo/' + token);
+    const data = await res.json();
+    if (data.exito) {
+        idReto = data.id_reto;
+        document.getElementById('codigo-reto').textContent = data.codigo;
+    } else {
+        document.getElementById('codigo-reto').textContent = '---';
+    }
+}
+
+async function verificar() {
+    const codigo = document.getElementById('respuesta').value;
+    const formData = new FormData();
+    formData.append('token', token);
+    formData.append('id_reto', idReto);
+    formData.append('codigo', codigo);
+    const res = await fetch('<?php echo URL_PATH; ?>asistencia/validarReto', { method:'POST', body: formData });
+    const data = await res.json();
+    if (data.exito) {
+        document.getElementById('mensaje').innerHTML = '<span class="text-success">Código correcto</span>';
+    } else {
+        document.getElementById('mensaje').innerHTML = '<span class="text-danger">Código incorrecto</span>';
+    }
+    document.getElementById('respuesta').value = '';
+}
+
+document.getElementById('btn-verificar').addEventListener('click', verificar);
+document.getElementById('btn-nuevo').addEventListener('click', cargarReto);
+setInterval(cargarReto, 15000);
+cargarReto();
+</script>

--- a/app/views/eventos/dashboard.php
+++ b/app/views/eventos/dashboard.php
@@ -1,0 +1,37 @@
+<?php
+// Vista sencilla de dashboard de retos
+$evento = $datos['evento'];
+$registros = $datos['registros'];
+?>
+<div class="container-fluid px-md-4 py-4">
+    <h1 class="h3 mb-4">Dashboard de Retos - <?php echo htmlspecialchars($evento->nombre_evento); ?></h1>
+    <div class="mb-3">
+        <button id="btn-manual" class="btn btn-primary">Emitir Reto Manual</button>
+    </div>
+    <div class="table-responsive">
+        <table class="table table-sm">
+            <thead>
+                <tr><th>Invitado</th><th>Reto</th><th>Estado</th></tr>
+            </thead>
+            <tbody id="tabla-registros">
+                <?php foreach ($registros as $r): ?>
+                <tr>
+                    <td><?php echo htmlspecialchars($r->nombre); ?></td>
+                    <td><?php echo $r->id_reto; ?></td>
+                    <td><?php echo $r->correcto ? '✅' : '❌'; ?></td>
+                </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+</div>
+<script>
+const btn = document.getElementById('btn-manual');
+btn.addEventListener('click', async () => {
+    const res = await fetch('<?php echo URL_PATH; ?>evento/emitirRetoManual/<?php echo $evento->id; ?>');
+    const data = await res.json();
+    if(data.exito){
+        alert('Reto emitido');
+    }
+});
+</script>

--- a/docs/verificacion_retos.md
+++ b/docs/verificacion_retos.md
@@ -1,0 +1,7 @@
+# Verificación con Retos Dinámicos
+
+El organizador puede emitir retos temporales para que los asistentes validen su presencia en eventos virtuales. Cada reto tiene un código que cambia cada 15 segundos.
+
+El asistente accede mediante su enlace personal `/asistencia/[token]` y ve el código activo. Debe ingresar dicho código para registrar su asistencia.
+
+Los registros se guardan en la tabla `registros_retos` con la hora, IP y resultado.

--- a/index.php
+++ b/index.php
@@ -16,6 +16,12 @@ $controllerName = $router->getController();
 $methodName = $router->getMethod();
 $params = $router->getParams();
 
+// Ruta abreviada: /asistencia/[token]
+if ($controllerName === 'asistencia' && preg_match('/^[a-f0-9]{64}$/i', $methodName)) {
+        $params = [$methodName];
+        $methodName = 'inicio';
+}
+
 // --- LISTA BLANCA ACTUALIZADA ---
 $rutas_publicas = [
 	// Controlador 'organizador'
@@ -31,8 +37,9 @@ $rutas_publicas = [
 	'organizador/noAutorizado',
 
 	// Controlador 'asistencia'
-	'asistencia/bienvenida',
-	'asistencia/iniciarVerificacion',     // <-- RUTA AÑADIDA: Permite el acceso a la página del escáner.
+        'asistencia/bienvenida',
+        'asistencia/inicio',
+        'asistencia/iniciarVerificacion',     // <-- RUTA AÑADIDA: Permite el acceso a la página del escáner.
 	'asistencia/mostrarDesafio',         // <-- RUTA AÑADIDA: Permite el acceso a la verificación con clave visual.
 	'asistencia/procesarClaveVisual',    // <-- RUTA AÑADIDA: Permite el envío del formulario de la clave visual.
 	'asistencia/registroAnonimo',


### PR DESCRIPTION
## Summary
- implement RetoModel and RegistroRetoModel for dynamic challenges
- route `/asistencia/[token]` now handled by `inicio`
- create page to show active challenge and verify code
- allow organizers to emit manual challenge and view dashboard
- document the new verification flow

## Testing
- `php -l app/model/RetoModel.php`
- `php -l app/model/RegistroRetoModel.php`
- `php -l app/controller/AsistenciaController.php`
- `php -l app/controller/EventoController.php`
- `php -l index.php`
- `php -l app/views/asistencia/espera_reto.php`


------
https://chatgpt.com/codex/tasks/task_e_688a97a06398832c8f6bc509a8741c41