### PR TITLE
Corrige error al seleccionar contactos

### DIFF
--- a/app/views/eventos/agregar_invitados.php
+++ b/app/views/eventos/agregar_invitados.php
@@ -56,12 +56,12 @@
 					<h5>Añadir un nuevo invitado manualmente</h5>
 					<p class="text-muted small">El contacto se guardará en tu libreta de direcciones y se invitará al evento.</p>
 					<div class="row g-3">
-						<div class="col-md-6"><label for="nombre_manual" class="form-label">Nombre Completo <span class="text-danger">*</span></label><input type="text" class="form-control" name="nombre_manual" id="nombre_manual" required></div>
-						<div class="col-md-6"><label for="email_manual" class="form-label">Correo Electrónico <span class="text-danger">*</span></label><input type="email" class="form-control" name="email_manual" id="email_manual" required></div>
-						<div class="col-12">
-							<label class="form-label">Teléfono Móvil <span class="text-danger">*</span></label>
-							<input type="tel" class="form-control" id="telefono_manual">
-						</div>
+                                               <div class="col-md-6"><label for="nombre_manual" class="form-label">Nombre Completo <span class="text-danger">*</span></label><input type="text" class="form-control" name="nombre_manual" id="nombre_manual" :required="modo === 'manual'" :disabled="modo !== 'manual'"></div>
+                                               <div class="col-md-6"><label for="email_manual" class="form-label">Correo Electrónico <span class="text-danger">*</span></label><input type="email" class="form-control" name="email_manual" id="email_manual" :required="modo === 'manual'" :disabled="modo !== 'manual'"></div>
+                                               <div class="col-12">
+                                                       <label class="form-label">Teléfono Móvil <span class="text-danger">*</span></label>
+                                                       <input type="tel" class="form-control" id="telefono_manual" :required="modo === 'manual'" :disabled="modo !== 'manual'">
+                                               </div>
 					</div>
 				</div>
 


### PR DESCRIPTION
## Summary
- Evita que los campos de registro manual sean requeridos cuando no se usa ese modo

## Testing
- `php -l app/views/eventos/agregar_invitados.php`
- `find app -name '*.php' | xargs php -l`

------
https://chatgpt.com/codex/tasks/task_e_688a9c226120832cba40df52d920eb3f