### PR TITLE
Implement dynamic challenge flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vocatorid
 
 Este proyecto gestiona eventos y el registro de asistencia. Originalmente se basaba en códigos QR,
-pero ahora incluye un sistema de verificación mediante retos dinámicos para eventos virtuales.
+pero ahora la verificación para eventos virtuales se realiza mediante retos dinámicos que pueden programarse en distintos momentos.
 
 Para los organizadores existe una guía con pasos a seguir cuando el kiosco muestra que el código QR es inválido o ha expirado. Puedes consultarla en [docs/guia_manejo_error_qr.md](docs/guia_manejo_error_qr.md).

--- a/app/controller/EventoController.php
+++ b/app/controller/EventoController.php
@@ -289,6 +289,27 @@ class EventoController extends Controller
                 }
         }
 
+        public function obtenerRegistrosReto($id_evento)
+        {
+                header('Content-Type: application/json');
+
+                $evento = $this->eventoModel->obtenerPorId($id_evento);
+                if (!$evento || $evento->id_organizador != $_SESSION['id_organizador']) {
+                        echo json_encode(['exito' => false]);
+                        return;
+                }
+
+                $registros = $this->registroRetoModel->obtenerPorEvento($id_evento);
+                $totalRetos = count($registros);
+                $completados = 0;
+                foreach ($registros as $r) {
+                        if ($r->correcto) $completados++;
+                }
+                $porcentaje = $totalRetos > 0 ? round(($completados / $totalRetos) * 100, 2) : 0;
+
+                echo json_encode(['exito' => true, 'porcentaje' => $porcentaje, 'registros' => $registros]);
+        }
+
 	private function crearMensaje($tipo, $mensaje)
 	{
 		if (session_status() === PHP_SESSION_NONE) {

--- a/app/model/RegistroRetoModel.php
+++ b/app/model/RegistroRetoModel.php
@@ -45,5 +45,19 @@ class RegistroRetoModel extends Model
             return [];
         }
     }
+
+    public function yaCompletado($id_reto, $id_invitacion)
+    {
+        $sql = "SELECT id FROM registros_retos WHERE id_reto = :id_reto AND id_invitacion = :id_invitacion AND correcto = 1 LIMIT 1";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':id_reto', $id_reto, PDO::PARAM_INT);
+            $stmt->bindParam(':id_invitacion', $id_invitacion, PDO::PARAM_INT);
+            $stmt->execute();
+            return $stmt->rowCount() > 0;
+        } catch (PDOException $e) {
+            return false;
+        }
+    }
 }
 ?>

--- a/app/model/RetoModel.php
+++ b/app/model/RetoModel.php
@@ -44,5 +44,18 @@ class RetoModel extends Model
             return false;
         }
     }
+
+    public function obtenerProximoPorEvento($id_evento)
+    {
+        $sql = "SELECT * FROM retos WHERE id_evento = :id_evento AND hora_inicio > NOW() ORDER BY hora_inicio ASC LIMIT 1";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':id_evento', $id_evento, PDO::PARAM_INT);
+            $stmt->execute();
+            return $stmt->fetch(PDO::FETCH_OBJ);
+        } catch (PDOException $e) {
+            return false;
+        }
+    }
 }
 ?>

--- a/app/views/asistencia/bienvenida.php
+++ b/app/views/asistencia/bienvenida.php
@@ -114,17 +114,17 @@ $invitacion = $datos['invitacion'];
 				</div>
 			</div>
 
-			<div class="text-center">
-				<p>Para completar el proceso, necesitarás escanear el código QR que se mostrará en la pantalla del evento.</p>
-				<?php if ($evento->modo == 'Presencial'): ?>
-					<p><strong>Asegúrate de estar en el lugar del evento y tener activado el GPS de tu dispositivo.</strong></p>
-				<?php elseif ($evento->modo == 'Hibrido'): ?>
-					<p><strong>Si asistes de forma presencial, asegúrate de estar en el lugar del evento y tener activado el GPS de tu dispositivo.</strong></p>
-				<?php endif; ?>
-				<a href="<?php echo URL_PATH; ?>asistencia/iniciarVerificacion/<?php echo $invitacion->token_acceso; ?>" class="btn btn-primary btn-lg mt-3">
-					<i class="bi bi-qr-code-scan me-2"></i> Iniciar Registro de Asistencia
-				</a>
-			</div>
+                        <div class="text-center">
+                                <p>Mantén esta página abierta. El organizador activará retos en momentos específicos para confirmar tu asistencia.</p>
+                                <?php if ($evento->modo == 'Presencial'): ?>
+                                        <p><strong>Asegúrate de estar en el lugar del evento y tener activado el GPS de tu dispositivo.</strong></p>
+                                <?php elseif ($evento->modo == 'Hibrido'): ?>
+                                        <p><strong>Si asistes de forma presencial, asegúrate de estar en el lugar del evento y tener activado el GPS de tu dispositivo.</strong></p>
+                                <?php endif; ?>
+                                <a href="<?php echo URL_PATH; ?>asistencia/inicio/<?php echo $invitacion->token_acceso; ?>" class="btn btn-primary btn-lg mt-3">
+                                        <i class="bi bi-shield-check me-2"></i> Iniciar Registro de Asistencia
+                                </a>
+                        </div>
 
 		<?php endif; ?>
 

--- a/app/views/eventos/dashboard.php
+++ b/app/views/eventos/dashboard.php
@@ -5,8 +5,9 @@ $registros = $datos['registros'];
 ?>
 <div class="container-fluid px-md-4 py-4">
     <h1 class="h3 mb-4">Dashboard de Retos - <?php echo htmlspecialchars($evento->nombre_evento); ?></h1>
-    <div class="mb-3">
+    <div class="mb-3 d-flex justify-content-between">
         <button id="btn-manual" class="btn btn-primary">Emitir Reto Manual</button>
+        <div id="porcentaje" class="fw-bold"></div>
     </div>
     <div class="table-responsive">
         <table class="table table-sm">
@@ -32,6 +33,24 @@ btn.addEventListener('click', async () => {
     const data = await res.json();
     if(data.exito){
         alert('Reto emitido');
+        cargarRegistros();
     }
 });
+
+async function cargarRegistros(){
+    const res = await fetch('<?php echo URL_PATH; ?>evento/obtenerRegistrosReto/<?php echo $evento->id; ?>');
+    const data = await res.json();
+    if(!data.exito) return;
+    const tbody = document.getElementById('tabla-registros');
+    tbody.innerHTML = '';
+    data.registros.forEach(r => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${r.nombre}</td><td>${r.id_reto}</td><td>${r.correcto ? '✅' : '❌'}</td>`;
+        tbody.appendChild(tr);
+    });
+    document.getElementById('porcentaje').textContent = 'Retos completados: ' + data.porcentaje + '%';
+}
+
+setInterval(cargarRegistros, 10000);
+window.addEventListener('load', cargarRegistros);
 </script>

--- a/docs/verificacion_retos.md
+++ b/docs/verificacion_retos.md
@@ -1,7 +1,9 @@
 # Verificación con Retos Dinámicos
 
-El organizador puede emitir retos temporales para que los asistentes validen su presencia en eventos virtuales. Cada reto tiene un código que cambia cada 15 segundos.
+El organizador puede emitir retos temporales para que los asistentes validen su presencia en eventos virtuales. Cada reto tiene un código que cambia de forma periódica.
+
+Cuando un evento cuenta con varios retos programados, la pantalla del asistente indica en cuánto tiempo se activará el siguiente. Al llegar la hora, el reto aparece automáticamente sin necesidad de recargar la página.
 
 El asistente accede mediante su enlace personal `/asistencia/[token]` y ve el código activo. Debe ingresar dicho código para registrar su asistencia.
 
-Los registros se guardan en la tabla `registros_retos` con la hora, IP y resultado.
+Los registros se guardan en la tabla `registros_retos` con la hora, IP y resultado. Si el código es correcto se genera además un registro en `registros_asistencia` asociado al reto correspondiente.


### PR DESCRIPTION
## Summary
- remove QR instructions from attendance welcome view
- use `/asistencia/inicio/<token>` to start the challenge
- add countdown and success messages to the challenge UI
- store attendance when a challenge code is correct
- add helper methods for challenges in models
- provide dashboard endpoint and auto-refresh with completion percentage
- document dynamic challenges

## Testing
- `php -l app/model/RegistroRetoModel.php`
- `php -l app/model/RetoModel.php`
- `php -l app/controller/AsistenciaController.php`
- `php -l app/controller/EventoController.php`
- `php -l app/views/asistencia/bienvenida.php`
- `php -l app/views/asistencia/espera_reto.php`
- `php -l app/views/eventos/dashboard.php`

------
https://chatgpt.com/codex/tasks/task_e_688aa12dda48832c9936545296a38de2