### PR TITLE
Add challenge management panel

### DIFF
--- a/app/model/RetoModel.php
+++ b/app/model/RetoModel.php
@@ -57,5 +57,55 @@ class RetoModel extends Model
             return false;
         }
     }
+
+    public function obtenerPorEvento($id_evento)
+    {
+        $sql = "SELECT r.*, (SELECT COUNT(*) FROM registros_asistencia ra WHERE ra.coordenadas_checkin = CONCAT('Reto ', r.id)) AS completados FROM retos r WHERE r.id_evento = :id_evento ORDER BY r.hora_inicio ASC";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':id_evento', $id_evento, PDO::PARAM_INT);
+            $stmt->execute();
+            return $stmt->fetchAll(PDO::FETCH_OBJ);
+        } catch (PDOException $e) {
+            return [];
+        }
+    }
+
+    public function obtenerPorId($id_reto)
+    {
+        $sql = "SELECT * FROM retos WHERE id = :id_reto";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':id_reto', $id_reto, PDO::PARAM_INT);
+            $stmt->execute();
+            return $stmt->fetch(PDO::FETCH_OBJ);
+        } catch (PDOException $e) {
+            return false;
+        }
+    }
+
+    public function activarAhora($id_reto)
+    {
+        $reto = $this->obtenerPorId($id_reto);
+        if (!$reto) {
+            return false;
+        }
+        $inicio_original = new DateTime($reto->hora_inicio);
+        $fin_original = new DateTime($reto->hora_fin);
+        $diff = $fin_original->getTimestamp() - $inicio_original->getTimestamp();
+        $nuevo_inicio = date('Y-m-d H:i:s');
+        $nuevo_fin = date('Y-m-d H:i:s', time() + $diff);
+
+        $sql = "UPDATE retos SET hora_inicio = :inicio, hora_fin = :fin WHERE id = :id";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':inicio', $nuevo_inicio);
+            $stmt->bindParam(':fin', $nuevo_fin);
+            $stmt->bindParam(':id', $id_reto, PDO::PARAM_INT);
+            return $stmt->execute();
+        } catch (PDOException $e) {
+            return false;
+        }
+    }
 }
 ?>

--- a/app/views/eventos/dashboard.php
+++ b/app/views/eventos/dashboard.php
@@ -1,56 +1,63 @@
 <?php
-// Vista sencilla de dashboard de retos
+// Panel avanzado de gestión de retos
 $evento = $datos['evento'];
-$registros = $datos['registros'];
 ?>
 <div class="container-fluid px-md-4 py-4">
-    <h1 class="h3 mb-4">Dashboard de Retos - <?php echo htmlspecialchars($evento->nombre_evento); ?></h1>
-    <div class="mb-3 d-flex justify-content-between">
-        <button id="btn-manual" class="btn btn-primary">Emitir Reto Manual</button>
-        <div id="porcentaje" class="fw-bold"></div>
-    </div>
+    <h1 class="h3 mb-4">Gestión de Retos de Asistencia - <?php echo htmlspecialchars($evento->nombre_evento); ?></h1>
+
+    <form id="form-reto" class="row g-2 mb-4">
+        <div class="col-md-4">
+            <input type="text" name="descripcion" class="form-control" placeholder="Descripción del Reto" required>
+        </div>
+        <div class="col-md-3">
+            <input type="datetime-local" name="hora_inicio" class="form-control" required>
+        </div>
+        <div class="col-md-3">
+            <input type="datetime-local" name="hora_fin" class="form-control" required>
+        </div>
+        <div class="col-md-2 d-grid">
+            <button class="btn btn-success">Crear Reto</button>
+        </div>
+    </form>
+
     <div class="table-responsive">
         <table class="table table-sm">
             <thead>
-                <tr><th>Invitado</th><th>Reto</th><th>Estado</th></tr>
-            </thead>
-            <tbody id="tabla-registros">
-                <?php foreach ($registros as $r): ?>
                 <tr>
-                    <td><?php echo htmlspecialchars($r->nombre); ?></td>
-                    <td><?php echo $r->id_reto; ?></td>
-                    <td><?php echo $r->correcto ? '✅' : '❌'; ?></td>
+                    <th>Descripción</th>
+                    <th>Inicio</th>
+                    <th>Fin</th>
+                    <th>Estado</th>
+                    <th>Completados</th>
+                    <th>Acciones</th>
                 </tr>
-                <?php endforeach; ?>
-            </tbody>
+            </thead>
+            <tbody id="lista-retos"></tbody>
         </table>
     </div>
 </div>
+
+<div class="modal fade" id="detalleModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Detalle de Reto</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="table-responsive">
+            <table class="table table-sm">
+                <thead><tr><th>Invitado</th><th>Código</th><th>Fecha</th></tr></thead>
+                <tbody id="detalle-body"></tbody>
+            </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <script>
-const btn = document.getElementById('btn-manual');
-btn.addEventListener('click', async () => {
-    const res = await fetch('<?php echo URL_PATH; ?>evento/emitirRetoManual/<?php echo $evento->id; ?>');
-    const data = await res.json();
-    if(data.exito){
-        alert('Reto emitido');
-        cargarRegistros();
-    }
-});
-
-async function cargarRegistros(){
-    const res = await fetch('<?php echo URL_PATH; ?>evento/obtenerRegistrosReto/<?php echo $evento->id; ?>');
-    const data = await res.json();
-    if(!data.exito) return;
-    const tbody = document.getElementById('tabla-registros');
-    tbody.innerHTML = '';
-    data.registros.forEach(r => {
-        const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${r.nombre}</td><td>${r.id_reto}</td><td>${r.correcto ? '✅' : '❌'}</td>`;
-        tbody.appendChild(tr);
-    });
-    document.getElementById('porcentaje').textContent = 'Retos completados: ' + data.porcentaje + '%';
-}
-
-setInterval(cargarRegistros, 10000);
-window.addEventListener('load', cargarRegistros);
+const URL_BASE = '<?php echo URL_PATH; ?>';
+const ID_EVENTO = <?php echo (int)$evento->id; ?>;
 </script>
+<script src="<?php echo URL_PATH; ?>core/customassets/js/retos_admin.js"></script>

--- a/core/customassets/js/retos_admin.js
+++ b/core/customassets/js/retos_admin.js
@@ -1,0 +1,65 @@
+// Gestion dinámica de retos para el dashboard del organizador
+
+async function cargarRetos(){
+    const res = await fetch(`${URL_BASE}evento/estadoRetos/${ID_EVENTO}`);
+    const data = await res.json();
+    if(!data.exito) return;
+    const tbody = document.getElementById('lista-retos');
+    tbody.innerHTML = '';
+    data.retos.forEach(r => {
+        const tr = document.createElement('tr');
+        let acciones = `<button class="btn btn-sm btn-secondary" onclick="verDetalles(${r.id})">Ver Detalles</button>`;
+        if(r.estado === 'Pendiente'){
+            acciones = `<button class="btn btn-sm btn-primary me-2" onclick="activarReto(${r.id})">Activar Ahora</button>` + acciones;
+        }
+        tr.innerHTML = `<td>${r.descripcion}</td><td>${r.hora_inicio}</td><td>${r.hora_fin}</td><td>${r.estado}</td><td>${r.completados}</td><td>${acciones}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+
+async function crearReto(ev){
+    ev.preventDefault();
+    const form = ev.target;
+    const formData = new FormData(form);
+    const res = await fetch(`${URL_BASE}evento/crearReto/${ID_EVENTO}`, {method:'POST', body: formData});
+    const data = await res.json();
+    if(data.exito){
+        form.reset();
+        alert('Reto creado correctamente');
+        cargarRetos();
+    }else{
+        alert('Error al crear reto');
+    }
+}
+
+async function activarReto(id){
+    const res = await fetch(`${URL_BASE}evento/activarReto/${id}`, {method:'POST'});
+    const data = await res.json();
+    if(data.exito){
+        cargarRetos();
+    }
+}
+
+async function verDetalles(id){
+    const res = await fetch(`${URL_BASE}evento/detalleReto/${id}`);
+    const data = await res.json();
+    if(!data.exito) return;
+    const tbody = document.getElementById('detalle-body');
+    tbody.innerHTML = '';
+    data.registros.forEach(r => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${r.nombre}</td><td>${r.codigo_ingresado}</td><td>${r.fecha_registro}</td>`;
+        tbody.appendChild(tr);
+    });
+    const modal = new bootstrap.Modal(document.getElementById('detalleModal'));
+    modal.show();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('form-reto');
+    if(form){
+        form.addEventListener('submit', crearReto);
+    }
+    cargarRetos();
+    setInterval(cargarRetos, 10000);
+});


### PR DESCRIPTION
## Summary
- implement CRUD-like challenge management
- add endpoints to create, activate and list challenges
- add JS helpers for realtime updates
- redesign dashboard view with forms and tables

## Testing
- `php -l app/model/RetoModel.php`
- `php -l app/controller/EventoController.php`
- `php -l app/views/eventos/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_688aa96f058c832cb47c0dacfe311138