### PR TITLE
Clarify gestionar.php routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ Para ver el detalle del nuevo flujo consulta
 [docs/verificacion_retos.md](docs/verificacion_retos.md). La guía
 sobre problemas con QR solo aplica al kiosco físico y está en
 [docs/guia_manejo_error_qr.md](docs/guia_manejo_error_qr.md).
+
+## Gestión de eventos
+
+Para administrar cada evento se utiliza la vista `app/views/eventos/gestionar.php`.
+El controlador `EventoController` expone el método `gestionar($id_evento)` y la
+ruta correspondiente es `/evento/gestionar/{id}`. Asegúrate de acceder a esta
+URL para cargar el archivo `gestionar.php`.

--- a/core/config/router.php
+++ b/core/config/router.php
@@ -17,28 +17,36 @@ class router
 		$this->setParams();
 	}
 
-	public function setUri()
-	{
-		// Obtenemos la URL y la limpiamos de la ruta base del proyecto si existe
-		$url = $_SERVER['REQUEST_URI'];
-		$base_path = str_replace('/index.php', '', $_SERVER['SCRIPT_NAME']);
-		$this->uri = str_replace($base_path, '', $url);
-		$this->uri = trim($this->uri, '/');
-	}
+        public function setUri()
+        {
+                // Obtenemos solo la ruta, sin la cadena de consulta
+                $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
 
-	public function setController()
-	{
-		// El controlador es el primer segmento de la URI. Si está vacío, por defecto es 'organizador'.
-		$uri_parts = !empty($this->uri) ? explode('/', $this->uri) : ['organizador'];
-		$this->controller = $uri_parts[0] ?: 'organizador';
-	}
+                // Eliminamos la ruta base del proyecto si existe
+                $base_path = str_replace('/index.php', '', $_SERVER['SCRIPT_NAME']);
+                $this->uri = str_replace($base_path, '', $path);
+                $this->uri = trim($this->uri, '/');
+        }
 
-	public function setMethod()
-	{
-		// El método es el segundo segmento. Si no existe, por defecto es 'index'.
-		$uri_parts = !empty($this->uri) ? explode('/', $this->uri) : [];
-		$this->method = isset($uri_parts[1]) && !empty($uri_parts[1]) ? $uri_parts[1] : 'index';
-	}
+       public function setController()
+       {
+               // El controlador es el primer segmento de la URI. Si está vacío, por defecto es 'organizador'.
+                $uri_parts = !empty($this->uri) ? explode('/', $this->uri) : ['organizador'];
+                $controller = $uri_parts[0] ?: 'organizador';
+                // Si viene con la extensión .php, la eliminamos
+                $controller = preg_replace('/\.php$/', '', $controller);
+                $this->controller = $controller;
+       }
+
+       public function setMethod()
+       {
+               // El método es el segundo segmento. Si no existe, por defecto es 'index'.
+                $uri_parts = !empty($this->uri) ? explode('/', $this->uri) : [];
+                $method = isset($uri_parts[1]) && !empty($uri_parts[1]) ? $uri_parts[1] : 'index';
+                // También quitamos la extensión .php si existe
+                $method = preg_replace('/\.php$/', '', $method);
+                $this->method = $method;
+       }
 
 	public function setParams()
 	{


### PR DESCRIPTION
## Summary
- update router to ignore query strings and `.php` suffixes
- document the gestionar.php view location and route

## Testing
- `php -l core/config/router.php`
- `php -l index.php`

------
https://chatgpt.com/codex/tasks/task_e_688ab2038e18832cb558cbb447cd3f35