### PR TITLE
Add visual challenge code generation

### DIFF
--- a/app/controller/AsistenciaController.php
+++ b/app/controller/AsistenciaController.php
@@ -5,6 +5,15 @@ require_once APP_BASE_PHYSICAL_PATH . '/app/services/BrevoMailService.php';
 
 class AsistenciaController extends Controller
 {
+        /**
+         * Paleta de colores disponibles para la generación del código
+         * visual. Esta lista es utilizada por otros componentes de la
+         * aplicación mediante la propiedad estática.
+         */
+        public static $colores = [
+                'Rojo', 'Verde', 'Azul', 'Amarillo',
+                'Negro', 'Blanco', 'Naranja', 'Morado'
+        ];
 
 	private $invitacionModel;
 	private $eventoModel;

--- a/app/controller/EventoController.php
+++ b/app/controller/EventoController.php
@@ -221,19 +221,37 @@ class EventoController extends Controller
 		}
 	}
 
-	public function kiosco($id_evento)
-	{
-		$evento = $this->eventoModel->obtenerPorId($id_evento);
-		if (!$evento) {
-			die('Este evento no existe.');
-		}
-		$datos = [
-			'titulo' => 'Kiosco - ' . $evento->nombre_evento,
-			'evento' => $evento
-		];
-		extract($datos);
-		require_once APP_BASE_PHYSICAL_PATH . '/app/views/eventos/kiosco.php';
-	}
+        public function kiosco($id_evento)
+        {
+                $evento = $this->eventoModel->obtenerPorId($id_evento);
+                if (!$evento) {
+                        die('Este evento no existe.');
+                }
+                $datos = [
+                        'titulo' => 'Kiosco - ' . $evento->nombre_evento,
+                        'evento' => $evento
+                ];
+                extract($datos);
+                require_once APP_BASE_PHYSICAL_PATH . '/app/views/eventos/kiosco.php';
+        }
+
+        /**
+         * Pantalla de Kiosko Virtual que muestra el código visual
+         * generado para el reto activo.
+         */
+        public function kioskoVirtual($id_evento)
+        {
+                $evento = $this->eventoModel->obtenerPorId($id_evento);
+                if (!$evento) {
+                        die('Este evento no existe.');
+                }
+                $datos = [
+                        'titulo' => 'Kiosko Virtual - ' . $evento->nombre_evento,
+                        'evento' => $evento
+                ];
+                extract($datos);
+                require_once APP_BASE_PHYSICAL_PATH . '/app/views/eventos/kiosko_virtual.php';
+        }
 
         public function generarTokenKiosco($id_evento)
         {

--- a/app/model/RetoModel.php
+++ b/app/model/RetoModel.php
@@ -32,6 +32,39 @@ class RetoModel extends Model
         }
     }
 
+    /**
+     * Actualiza el código y registra la fecha de actualización
+     * en la columna codigo_actual_timestamp si existe.
+     */
+    public function actualizarCodigoYFecha($id_reto, $codigo_actual)
+    {
+        $sql = "UPDATE retos SET codigo_actual = :codigo_actual, codigo_actual_timestamp = NOW() WHERE id = :id_reto";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':codigo_actual', $codigo_actual);
+            $stmt->bindParam(':id_reto', $id_reto, PDO::PARAM_INT);
+            return $stmt->execute();
+        } catch (PDOException $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Actualiza únicamente la fecha de la última generación
+     * del código visual.
+     */
+    public function actualizarFechaCodigo($id_reto)
+    {
+        $sql = "UPDATE retos SET codigo_actual_timestamp = NOW() WHERE id = :id_reto";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':id_reto', $id_reto, PDO::PARAM_INT);
+            return $stmt->execute();
+        } catch (PDOException $e) {
+            return false;
+        }
+    }
+
     public function obtenerActivoPorEvento($id_evento)
     {
         $sql = "SELECT * FROM retos WHERE id_evento = :id_evento AND hora_inicio <= NOW() AND hora_fin >= NOW() ORDER BY id DESC LIMIT 1";

--- a/app/views/asistencia/espera_reto.php
+++ b/app/views/asistencia/espera_reto.php
@@ -6,17 +6,22 @@ $invitacion = $datos['invitacion'];
     <div class="w-100" style="max-width: 600px; margin:auto;">
         <div class="text-center mb-4">
             <h1 class="h2 mb-3">Verificación de Asistencia</h1>
-            <p class="lead text-muted">Ingresa el código que se muestra en pantalla.</p>
+            <p class="lead text-muted">Ingresa el código que ves en la pantalla del organizador.</p>
+        </div>
+        <div class="alert alert-success d-flex align-items-center mb-4" role="alert">
+            <i class="bi bi-check-circle-fill me-2"></i>
+            <div>
+                <strong>Paso 1 – Completado</strong><br>
+                <small>Sabemos que eres tú, porque accediste con tu enlace único de seguridad.</small>
+            </div>
         </div>
         <div class="card shadow-sm">
             <div class="card-body text-center" id="reto-container">
-                <h3 id="codigo-reto" class="display-4">---</h3>
                 <div class="mb-3">
-                    <input type="text" id="respuesta" class="form-control text-center" placeholder="Código" maxlength="6">
+                    <input type="text" id="respuesta" class="form-control text-center" placeholder="Código" maxlength="30">
                 </div>
                 <div class="d-grid gap-2">
                     <button id="btn-verificar" class="btn btn-primary">Verificar</button>
-                    <button id="btn-nuevo" class="btn btn-outline-secondary">Generar Nuevo Reto</button>
                 </div>
                 <div id="mensaje" class="mt-3"></div>
                 <div id="contador" class="text-muted small"></div>
@@ -35,16 +40,13 @@ async function cargarReto() {
     const data = await res.json();
     if (data.exito) {
         idReto = data.id_reto;
-        document.getElementById('codigo-reto').textContent = data.codigo;
         document.getElementById('contador').textContent = '';
         if(countdownInterval) clearInterval(countdownInterval);
     } else if (data.proximo_en) {
         idReto = 0;
         proximoEn = data.proximo_en;
         iniciarContador();
-        document.getElementById('codigo-reto').textContent = '---';
     } else {
-        document.getElementById('codigo-reto').textContent = '---';
         document.getElementById('contador').textContent = '';
     }
 }
@@ -60,7 +62,6 @@ async function verificar() {
     if (data.exito) {
         document.getElementById('mensaje').innerHTML = '<span class="text-success">✅ Asistencia registrada</span>';
         document.getElementById('btn-verificar').disabled = true;
-        document.getElementById('btn-nuevo').disabled = true;
     } else {
         const msg = data.mensaje ? data.mensaje : 'Código incorrecto';
         document.getElementById('mensaje').innerHTML = '<span class="text-danger">' + msg + '</span>';
@@ -83,7 +84,6 @@ function iniciarContador(){
 }
 
 document.getElementById('btn-verificar').addEventListener('click', verificar);
-document.getElementById('btn-nuevo').addEventListener('click', cargarReto);
 setInterval(cargarReto, 15000);
 cargarReto();
 </script>

--- a/app/views/eventos/gestionar.php
+++ b/app/views/eventos/gestionar.php
@@ -233,7 +233,7 @@ $porcentaje_eficiencia = ($total_invitados > 0) ? ($total_registrados / $total_i
 							<div class="btn-group" role="group">
 								<?php if ($evento->estado != 'Borrador'): ?>
 									<?php if ($evento->modo == 'Virtual' || $evento->modo == 'Hibrido'): ?>
-										<a href="<?php echo URL_PATH; ?>evento/kiosco/<?php echo $evento->id; ?>" target="_blank" class="btn btn-sm btn-outline-info" title="Abrir Kiosco Virtual"><i class="bi bi-display-fill me-1"></i>Kiosco Virtual</a>
+                                                                       <a href="<?php echo URL_PATH; ?>evento/kioskoVirtual/<?php echo $evento->id; ?>" target="_blank" class="btn btn-sm btn-outline-info" title="Abrir Kiosco Virtual"><i class="bi bi-display-fill me-1"></i>Kiosco Virtual</a>
 									<?php endif; ?>
 									<?php if ($evento->modo == 'Presencial' || $evento->modo == 'Hibrido'): ?>
 										<a href="<?php echo URL_PATH; ?>kioscoFisico/scanner/<?php echo $evento->id; ?>" target="_blank" class="btn btn-sm btn-outline-dark" title="Abrir Kiosco Físico"><i class="bi bi-qr-code-scan me-1"></i>Kiosco Físico</a>

--- a/app/views/eventos/kiosko_virtual.php
+++ b/app/views/eventos/kiosko_virtual.php
@@ -1,0 +1,252 @@
+<?php
+// El header.php se carga automáticamente desde el controlador.
+$evento = $datos['evento'];
+?>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+
+<style>
+	html,
+	body {
+		height: 100%;
+		margin: 0;
+		padding: 0;
+		overflow: hidden;
+	}
+
+	body {
+		background: #1c1c1c;
+		color: #f8f9fa;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		text-align: center;
+		font-family: 'Poppins', sans-serif;
+	}
+
+	.background-gradient {
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		background: linear-gradient(45deg, #0d6efd, #6f42c1, #d63384);
+		background-size: 400% 400%;
+		animation: gradientAnimation 15s ease infinite;
+		filter: blur(150px);
+		z-index: -1;
+	}
+
+	@keyframes gradientAnimation {
+		0% {
+			background-position: 0% 50%;
+		}
+
+		50% {
+			background-position: 100% 50%;
+		}
+
+		100% {
+			background-position: 0% 50%;
+		}
+	}
+
+	.kiosco-container {
+		width: 100%;
+		max-width: 500px;
+		padding: 2rem;
+	}
+
+	.card-kiosco {
+		background-color: rgba(33, 37, 41, 0.75);
+		border-radius: 1.5rem;
+		padding: 2.5rem;
+		border: 1px solid rgba(255, 255, 255, 0.1);
+		box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+		backdrop-filter: blur(15px);
+		-webkit-backdrop-filter: blur(15px);
+	}
+
+
+	.codigo-texto {
+		font-family: 'Share Tech Mono', monospace;
+		font-size: 4.5rem;
+		font-weight: 400;
+		letter-spacing: 0.5rem;
+		color: #fff;
+		line-height: 1;
+		margin-top: 1rem;
+		text-shadow: 0 0 10px rgba(13, 202, 240, 0.5);
+	}
+
+	.progress-container {
+		display: flex;
+		align-items: center;
+		gap: 15px;
+		margin-top: 2rem;
+	}
+
+	.progress {
+		flex-grow: 1;
+		height: 8px;
+		background-color: rgba(255, 255, 255, 0.1);
+		border-radius: 8px;
+		overflow: hidden;
+	}
+
+	/* Esta clase ahora se aplica al div interior con id="progress-bar" */
+	#progress-bar {
+		transition: background-color 0.5s ease, width 0.2s ease !important;
+		border-radius: 8px;
+	}
+
+	.progress-bar-white {
+		background-color: #f8f9fa;
+	}
+
+        .progress-bar-black {
+                background-color: #000000;
+        }
+
+
+	#minutos-restantes {
+		font-family: 'Share Tech Mono', monospace;
+		font-size: 1.2rem;
+		color: #adb5bd;
+		flex-shrink: 0;
+	}
+
+	@keyframes blink-animation {
+		50% {
+			opacity: 0.2;
+		}
+	}
+
+	.blinking-bar {
+		animation: blink-animation 1s infinite;
+	}
+
+	.event-title {
+		font-weight: 700;
+		color: #ffffff;
+	}
+
+	.event-details {
+		color: #e9ecef;
+		font-weight: 300;
+		border-top: 1px solid rgba(255, 255, 255, 0.1);
+		padding-top: 1rem;
+		margin-top: 1rem;
+	}
+
+	.text-muted {
+		color: #adb5bd !important;
+	}
+</style>
+</head>
+
+<body>
+
+	<div class="background-gradient"></div>
+
+	<div class="kiosco-container">
+		<div class="card-kiosco">
+			<h1 class="event-title h2"><?php echo htmlspecialchars($evento->nombre_evento); ?></h1>
+
+                        <p class="text-muted mt-4">Código vigente:</p>
+			<div id="codigo-texto" class="codigo-texto">CARGANDO...</div>
+
+			<div class="progress-container">
+				<div class="progress">
+					<div id="progress-bar" class="progress" role="progressbar" style="width: 100%"></div>
+				</div>
+				<div id="minutos-restantes">--:--</div>
+			</div>
+
+			<div class="event-details mt-3">
+				<small><i class="bi bi-calendar-event me-2"></i><?php echo date('d/m/Y', strtotime($evento->fecha_evento)); ?></small>
+				<?php if (!empty($evento->nombre_instructor)): ?>
+					<small><i class="bi bi-person-video3 me-2"></i><?php echo htmlspecialchars($evento->nombre_instructor); ?></small>
+				<?php endif; ?>
+			</div>
+		</div>
+	</div>
+
+	<script>
+                document.addEventListener('DOMContentLoaded', function() {
+                        const codigoTextoElem = document.getElementById('codigo-texto');
+                        const progressBar = document.getElementById('progress-bar');
+                        const minutosRestantesElem = document.getElementById('minutos-restantes');
+                        let countdownInterval = null;
+
+			function iniciarContador(duracion) {
+				clearInterval(countdownInterval);
+                                progressBar.classList.remove('blinking-bar', 'progress-bar-white', 'progress-bar-black');
+
+				let segundosRestantes = duracion;
+
+				function actualizarVista() {
+					const minutos = Math.floor(segundosRestantes / 60);
+					const segundos = segundosRestantes % 60;
+					minutosRestantesElem.textContent = `${minutos.toString().padStart(2, '0')}:${segundos.toString().padStart(2, '0')}`;
+
+					const progreso = (segundosRestantes / duracion) * 100;
+					progressBar.style.width = progreso + '%';
+
+					const bloqueActual = Math.floor((duracion - segundosRestantes) / 5);
+                                        if (bloqueActual % 2 === 0) {
+                                                progressBar.classList.remove('progress-bar-black');
+                                                progressBar.classList.add('progress-bar-white');
+                                        } else {
+                                                progressBar.classList.remove('progress-bar-white');
+                                                progressBar.classList.add('progress-bar-black');
+                                        }
+
+                                        // Parpadeo al faltar 15 segundos
+                                        if (segundosRestantes <= 15) {
+                                                progressBar.classList.add('blinking-bar');
+                                        } else {
+                                                progressBar.classList.remove('blinking-bar');
+                                        }
+				}
+
+				actualizarVista();
+
+				countdownInterval = setInterval(() => {
+					segundosRestantes--;
+					actualizarVista();
+
+					if (segundosRestantes < 0) {
+						clearInterval(countdownInterval);
+						actualizarToken();
+					}
+				}, 1000);
+			}
+
+                        async function actualizarToken() {
+                                try {
+                                        const response = await fetch('<?php echo URL_PATH; ?>get_codigo_reto.php?id_evento=<?php echo $evento->id; ?>');
+                                        if (!response.ok) throw new Error('Error de red');
+
+                                        const data = await response.json();
+
+                                        if (data.estado === 'activo') {
+                                                codigoTextoElem.textContent = data.codigo_actual;
+                                                iniciarContador(data.tiempo_restante);
+                                        } else {
+                                                codigoTextoElem.textContent = 'INACTIVO';
+                                        }
+                                } catch (error) {
+                                        console.error('Error al obtener el código:', error);
+                                        codigoTextoElem.textContent = 'ERROR';
+                                }
+                        }
+
+                        actualizarToken();
+		});
+	</script>
+
+</body>
+
+</html>

--- a/core/config/recursos.php
+++ b/core/config/recursos.php
@@ -107,3 +107,22 @@ function obtenerRecursosClaveVisual()
 	];
 }
 
+/**
+ * Genera un código visual aleatorio en el formato
+ * [Fruta]-[Color]-[Animal] utilizando los recursos
+ * disponibles en el sistema.
+ *
+ * @param array $colores Lista de colores a utilizar.
+ * @return string Código generado.
+ */
+function generarCodigoFrutasColoresAnimales($colores)
+{
+        $recursos = obtenerRecursosClaveVisual();
+
+        $fruta = basename($recursos['frutas'][array_rand($recursos['frutas'])], '.jpg');
+        $animal = basename($recursos['animales'][array_rand($recursos['animales'])], '.jpg');
+        $color = $colores[array_rand($colores)];
+
+        return $fruta . '-' . $color . '-' . $animal;
+}
+

--- a/get_codigo_reto.php
+++ b/get_codigo_reto.php
@@ -1,0 +1,44 @@
+<?php
+require_once __DIR__ . '/core/config/config.php';
+require_once APP_BASE_PHYSICAL_PATH . '/core/config/conn.php';
+require_once APP_BASE_PHYSICAL_PATH . '/core/Model.php';
+require_once APP_BASE_PHYSICAL_PATH . '/app/model/RetoModel.php';
+require_once APP_BASE_PHYSICAL_PATH . '/app/controller/AsistenciaController.php';
+require_once APP_BASE_PHYSICAL_PATH . '/core/config/recursos.php';
+
+header('Content-Type: application/json');
+
+$id_evento = isset($_GET['id_evento']) ? (int)$_GET['id_evento'] : 0;
+
+$retoModel = new RetoModel();
+$reto = $retoModel->obtenerActivoPorEvento($id_evento);
+
+if (!$reto) {
+    echo json_encode(['estado' => 'inactivo']);
+    exit;
+}
+
+$timestamp = isset($reto->codigo_actual_timestamp) ? strtotime($reto->codigo_actual_timestamp) : time();
+$ahora = time();
+
+if (empty($reto->codigo_actual) || ($ahora - $timestamp) >= 40) {
+    $codigo = generarCodigoFrutasColoresAnimales(AsistenciaController::$colores);
+    if (method_exists($retoModel, 'actualizarCodigoYFecha')) {
+        $retoModel->actualizarCodigoYFecha($reto->id, $codigo);
+    } else {
+        $retoModel->actualizarCodigo($reto->id, $codigo);
+    }
+    $reto->codigo_actual = $codigo;
+    $timestamp = $ahora;
+}
+
+$tiempo_restante = 40 - ($ahora - $timestamp);
+if ($tiempo_restante < 0) {
+    $tiempo_restante = 0;
+}
+
+echo json_encode([
+    'codigo_actual' => $reto->codigo_actual,
+    'tiempo_restante' => $tiempo_restante,
+    'estado' => 'activo'
+]);


### PR DESCRIPTION
## Summary
- define color list in `AsistenciaController`
- add `generarCodigoFrutasColoresAnimales` helper
- extend `RetoModel` with timestamp helpers
- provide endpoint `get_codigo_reto.php` for dynamic codes
- create `kioskoVirtual` screen to display the code with animated progress
- update organizer dashboard link and attendee page layout

## Testing
- `php -l app/controller/AsistenciaController.php`
- `php -l core/config/recursos.php`
- `php -l app/model/RetoModel.php`
- `php -l app/controller/EventoController.php`
- `php -l get_codigo_reto.php`
- `php -l app/views/eventos/kiosko_virtual.php`
- `php -l app/views/eventos/gestionar.php`
- `php -l app/views/asistencia/espera_reto.php`


------
https://chatgpt.com/codex/tasks/task_e_688ad3ca27d8832cb172ff3cee479032