### PR TITLE
Add dynamic visual codes for attendance

### DIFF
--- a/app/views/asistencia/espera_reto.php
+++ b/app/views/asistencia/espera_reto.php
@@ -2,6 +2,37 @@
 $evento = $datos['evento'];
 $invitacion = $datos['invitacion'];
 ?>
+<style>
+    .reto-visual {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 20px;
+    }
+    .reto-img {
+        width: 60px;
+        height: 60px;
+        object-fit: contain;
+    }
+    .color-btn {
+        width: 40px;
+        height: 40px;
+        border: none;
+    }
+    .progress-container {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+    #progress-bar {
+        transition: background-color 0.5s ease, width 0.2s ease!important;
+        border-radius: 8px;
+    }
+    .progress-bar-white { background-color: #f8f9fa; }
+    .progress-bar-black { background-color: #000000; }
+    @keyframes blink-animation { 50% { opacity: 0.2; } }
+    .blinking-bar { animation: blink-animation 1s infinite; }
+</style>
 <div class="container container-main d-flex align-items-center">
     <div class="w-100" style="max-width: 600px; margin:auto;">
         <div class="text-center mb-4">
@@ -17,6 +48,17 @@ $invitacion = $datos['invitacion'];
         </div>
         <div class="card shadow-sm">
             <div class="card-body text-center" id="reto-container">
+                <div class="reto-visual mb-3">
+                    <img id="fruta" class="reto-img" src="" alt="fruta">
+                    <button id="color-boton" class="color-btn"></button>
+                    <img id="animal" class="reto-img" src="" alt="animal">
+                </div>
+                <div class="progress-container mb-3">
+                    <div class="progress flex-grow-1">
+                        <div id="progress-bar" class="progress-bar" role="progressbar" style="width:100%"></div>
+                    </div>
+                    <div id="contador" class="text-muted small">--:--</div>
+                </div>
                 <div class="mb-3">
                     <input type="text" id="respuesta" class="form-control text-center" placeholder="Código" maxlength="30">
                 </div>
@@ -24,7 +66,6 @@ $invitacion = $datos['invitacion'];
                     <button id="btn-verificar" class="btn btn-primary">Verificar</button>
                 </div>
                 <div id="mensaje" class="mt-3"></div>
-                <div id="contador" class="text-muted small"></div>
             </div>
         </div>
     </div>
@@ -34,20 +75,27 @@ const token = '<?php echo $invitacion->token_acceso; ?>';
 let idReto = 0;
 let proximoEn = 0;
 let countdownInterval = null;
+const frutaElem = document.getElementById('fruta');
+const animalElem = document.getElementById('animal');
+const colorBtn = document.getElementById('color-boton');
+const progressBar = document.getElementById('progress-bar');
+const contadorElem = document.getElementById('contador');
 
 async function cargarReto() {
     const res = await fetch('<?php echo URL_PATH; ?>asistencia/obtenerRetoActivo/' + token);
     const data = await res.json();
     if (data.exito) {
         idReto = data.id_reto;
-        document.getElementById('contador').textContent = '';
-        if(countdownInterval) clearInterval(countdownInterval);
+        frutaElem.src = data.fruta_img;
+        animalElem.src = data.animal_img;
+        colorBtn.style.backgroundColor = data.color_hex;
+        iniciarBarra(data.tiempo_restante);
     } else if (data.proximo_en) {
         idReto = 0;
         proximoEn = data.proximo_en;
         iniciarContador();
     } else {
-        document.getElementById('contador').textContent = '';
+        contadorElem.textContent = '';
     }
 }
 
@@ -69,16 +117,52 @@ async function verificar() {
     document.getElementById('respuesta').value = '';
 }
 
+function iniciarBarra(duracion){
+    clearInterval(countdownInterval);
+    progressBar.classList.remove('blinking-bar','progress-bar-white','progress-bar-black');
+    let segundosRestantes = duracion;
+
+    function actualizar(){
+        contadorElem.textContent = segundosRestantes + 's';
+        const progreso = (segundosRestantes / duracion) * 100;
+        progressBar.style.width = progreso + '%';
+        const bloqueActual = Math.floor((duracion - segundosRestantes) / 5);
+        if(bloqueActual % 2 === 0){
+            progressBar.classList.remove('progress-bar-black');
+            progressBar.classList.add('progress-bar-white');
+        } else {
+            progressBar.classList.remove('progress-bar-white');
+            progressBar.classList.add('progress-bar-black');
+        }
+        if(segundosRestantes <= 15){
+            progressBar.classList.add('blinking-bar');
+        } else {
+            progressBar.classList.remove('blinking-bar');
+        }
+    }
+
+    actualizar();
+    countdownInterval = setInterval(() => {
+        segundosRestantes--;
+        actualizar();
+        if(segundosRestantes < 0){
+            clearInterval(countdownInterval);
+            cargarReto();
+        }
+    },1000);
+}
+
 function iniciarContador(){
     if(countdownInterval) clearInterval(countdownInterval);
     countdownInterval = setInterval(() => {
         if(proximoEn <= 0){
             clearInterval(countdownInterval);
-            document.getElementById('contador').textContent = 'Activando nuevo reto...';
+            contadorElem.textContent = 'Activando nuevo reto...';
+            progressBar.style.width = '0%';
             cargarReto();
             return;
         }
-        document.getElementById('contador').textContent = 'Próximo reto en ' + proximoEn + 's';
+        contadorElem.textContent = 'Próximo reto en ' + proximoEn + 's';
         proximoEn--;
     },1000);
 }

--- a/app/views/eventos/kiosko_virtual.php
+++ b/app/views/eventos/kiosko_virtual.php
@@ -69,16 +69,25 @@ $evento = $datos['evento'];
 	}
 
 
-	.codigo-texto {
-		font-family: 'Share Tech Mono', monospace;
-		font-size: 4.5rem;
-		font-weight: 400;
-		letter-spacing: 0.5rem;
-		color: #fff;
-		line-height: 1;
-		margin-top: 1rem;
-		text-shadow: 0 0 10px rgba(13, 202, 240, 0.5);
-	}
+        .reto-visual {
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                gap: 20px;
+                margin: 1.5rem 0;
+        }
+
+        .reto-img {
+                width: 80px;
+                height: 80px;
+                object-fit: contain;
+        }
+
+        .color-btn {
+                width: 50px;
+                height: 50px;
+                border: none;
+        }
 
 	.progress-container {
 		display: flex;
@@ -155,7 +164,11 @@ $evento = $datos['evento'];
 			<h1 class="event-title h2"><?php echo htmlspecialchars($evento->nombre_evento); ?></h1>
 
                         <p class="text-muted mt-4">Código vigente:</p>
-			<div id="codigo-texto" class="codigo-texto">CARGANDO...</div>
+                        <div class="reto-visual">
+                                <img id="fruta" class="reto-img" src="" alt="fruta">
+                                <button id="color-boton" class="color-btn"></button>
+                                <img id="animal" class="reto-img" src="" alt="animal">
+                        </div>
 
 			<div class="progress-container">
 				<div class="progress">
@@ -175,7 +188,9 @@ $evento = $datos['evento'];
 
 	<script>
                 document.addEventListener('DOMContentLoaded', function() {
-                        const codigoTextoElem = document.getElementById('codigo-texto');
+                        const frutaElem = document.getElementById('fruta');
+                        const animalElem = document.getElementById('animal');
+                        const colorBtn = document.getElementById('color-boton');
                         const progressBar = document.getElementById('progress-bar');
                         const minutosRestantesElem = document.getElementById('minutos-restantes');
                         let countdownInterval = null;
@@ -232,14 +247,17 @@ $evento = $datos['evento'];
                                         const data = await response.json();
 
                                         if (data.estado === 'activo') {
-                                                codigoTextoElem.textContent = data.codigo_actual;
+                                                frutaElem.src = data.fruta_img;
+                                                animalElem.src = data.animal_img;
+                                                colorBtn.style.backgroundColor = data.color_hex;
                                                 iniciarContador(data.tiempo_restante);
                                         } else {
-                                                codigoTextoElem.textContent = 'INACTIVO';
+                                                frutaElem.src = '';
+                                                animalElem.src = '';
+                                                colorBtn.style.backgroundColor = '#ffffff';
                                         }
                                 } catch (error) {
                                         console.error('Error al obtener el código:', error);
-                                        codigoTextoElem.textContent = 'ERROR';
                                 }
                         }
 

--- a/core/config/recursos.php
+++ b/core/config/recursos.php
@@ -119,10 +119,43 @@ function generarCodigoFrutasColoresAnimales($colores)
 {
         $recursos = obtenerRecursosClaveVisual();
 
-        $fruta = basename($recursos['frutas'][array_rand($recursos['frutas'])], '.jpg');
-        $animal = basename($recursos['animales'][array_rand($recursos['animales'])], '.jpg');
-        $color = $colores[array_rand($colores)];
+        $frutaArchivo = $recursos['frutas'][array_rand($recursos['frutas'])];
+        $animalArchivo = $recursos['animales'][array_rand($recursos['animales'])];
 
-        return $fruta . '-' . $color . '-' . $animal;
+        $fruta = basename($frutaArchivo, '.jpg');
+        $animal = basename($animalArchivo, '.jpg');
+
+        // $colores es un array asociativo nombre => hex
+        $colorNombre = array_rand($colores);
+        $colorHex = $colores[$colorNombre];
+
+        $codigo = $fruta . '-' . $colorNombre . '-' . $animal;
+
+        return [
+                'codigo' => $codigo,
+                'fruta_img'  => URL_PATH . 'core/img/clave_visual/frutas/' . $frutaArchivo,
+                'color_hex'  => $colorHex,
+                'animal_img' => URL_PATH . 'core/img/clave_visual/animales/' . $animalArchivo
+        ];
+}
+
+/**
+ * Devuelve las rutas de imágenes y el color HEX a partir del código
+ * almacenado en la base de datos.
+ */
+function datosDesdeCodigoVisual($codigo, $colores)
+{
+        $partes = explode('-', $codigo);
+        if (count($partes) !== 3) {
+                return null;
+        }
+
+        list($fruta, $colorNombre, $animal) = $partes;
+
+        return [
+                'fruta_img'  => URL_PATH . 'core/img/clave_visual/frutas/' . $fruta . '.jpg',
+                'color_hex'  => $colores[$colorNombre] ?? '#000000',
+                'animal_img' => URL_PATH . 'core/img/clave_visual/animales/' . $animal . '.jpg'
+        ];
 }
 

--- a/get_codigo_reto.php
+++ b/get_codigo_reto.php
@@ -22,7 +22,8 @@ $timestamp = isset($reto->codigo_actual_timestamp) ? strtotime($reto->codigo_act
 $ahora = time();
 
 if (empty($reto->codigo_actual) || ($ahora - $timestamp) >= 40) {
-    $codigo = generarCodigoFrutasColoresAnimales(AsistenciaController::$colores);
+    $datos = generarCodigoFrutasColoresAnimales(AsistenciaController::$colores);
+    $codigo = $datos['codigo'];
     if (method_exists($retoModel, 'actualizarCodigoYFecha')) {
         $retoModel->actualizarCodigoYFecha($reto->id, $codigo);
     } else {
@@ -30,6 +31,8 @@ if (empty($reto->codigo_actual) || ($ahora - $timestamp) >= 40) {
     }
     $reto->codigo_actual = $codigo;
     $timestamp = $ahora;
+} else {
+    $datos = datosDesdeCodigoVisual($reto->codigo_actual, AsistenciaController::$colores);
 }
 
 $tiempo_restante = 40 - ($ahora - $timestamp);
@@ -37,8 +40,7 @@ if ($tiempo_restante < 0) {
     $tiempo_restante = 0;
 }
 
-echo json_encode([
-    'codigo_actual' => $reto->codigo_actual,
+echo json_encode(array_merge($datos, [
     'tiempo_restante' => $tiempo_restante,
     'estado' => 'activo'
-]);
+]));


### PR DESCRIPTION
## Summary
- map challenge colors to HEX values
- generate fruit/color/animal codes with image URLs
- expose code details via `get_codigo_reto.php`
- display visual challenge in kiosk virtual view
- show same design on attendee verification screen

## Testing
- `php -l app/controller/AsistenciaController.php`
- `php -l get_codigo_reto.php`
- `php -l app/views/eventos/kiosko_virtual.php`
- `php -l app/views/asistencia/espera_reto.php`
- `php -l core/config/recursos.php`

------
https://chatgpt.com/codex/tasks/task_e_688ae4da5758832c97518b622880d726