### PR TITLE
Add visual challenge selections

### DIFF
--- a/get_codigo_reto.php
+++ b/get_codigo_reto.php
@@ -24,6 +24,7 @@ $ahora = time();
 if (empty($reto->codigo_actual) || ($ahora - $timestamp) >= 40) {
     $datos = generarCodigoFrutasColoresAnimales(AsistenciaController::$colores);
     $codigo = $datos['codigo'];
+    unset($datos['codigo']);
     if (method_exists($retoModel, 'actualizarCodigoYFecha')) {
         $retoModel->actualizarCodigoYFecha($reto->id, $codigo);
     } else {


### PR DESCRIPTION
## Summary
- style verification cards with white background
- show visual options for fruit, color, and animal
- update challenge loading logic to use image buttons
- exclude code from `get_codigo_reto.php` JSON

## Testing
- `php -l app/views/asistencia/espera_reto.php`
- `php -l app/views/eventos/kiosko_virtual.php`
- `php -l get_codigo_reto.php`


------
https://chatgpt.com/codex/tasks/task_e_688b70a02ee4832c9fcc20430333fdc1