### PR TITLE
Fix dynamic challenge UI

### DIFF
--- a/app/views/asistencia/espera_reto.php
+++ b/app/views/asistencia/espera_reto.php
@@ -17,14 +17,18 @@ require_once APP_BASE_PHYSICAL_PATH . '/app/controller/AsistenciaController.php'
         align-items: center;
         gap: 20px;
     }
+    .reto-visual img,
+    .reto-visual button {
+        border: 2px solid black;
+    }
     .reto-img {
-        width: 100px;
-        height: 100px;
+        width: 80px;
+        height: 80px;
         object-fit: contain;
     }
     .color-btn {
         width: 50px;
-        height: 50px;
+        height: 80px;
         border: none;
     }
     .opciones-list {
@@ -39,20 +43,19 @@ require_once APP_BASE_PHYSICAL_PATH . '/app/controller/AsistenciaController.php'
         height: 80px;
         object-fit: contain;
         cursor: pointer;
-        border: 3px solid transparent;
-        border-radius: 8px;
+        border: 2px solid transparent;
+        border-radius: 5px;
     }
     .opcion-seleccionada {
-        border: 3px solid #2ecc71;
-        border-radius: 5px;
+        border: 2px solid #2ecc71 !important;
     }
     .color-option {
         width: 50px;
-        height: 50px;
+        height: 80px;
         border: none;
         cursor: pointer;
-        border: 3px solid transparent;
-        border-radius: 4px;
+        border: 2px solid transparent;
+        border-radius: 5px;
     }
     .progress-container {
         display: flex;
@@ -218,7 +221,7 @@ async function verificar() {
     formData.append('fruta', frutaSel);
     formData.append('color', colorSel);
     formData.append('animal', animalSel);
-    const res = await fetch('<?php echo URL_PATH; ?>asistencia/validarReto', { method:'POST', body: formData });
+    const res = await fetch('<?php echo URL_PATH; ?>validar_reto.php', { method:'POST', body: formData });
     const data = await res.json();
     if (data.exito) {
         document.getElementById('mensaje').innerHTML = '<span class="text-success">✅ Asistencia registrada</span>';

--- a/validar_reto.php
+++ b/validar_reto.php
@@ -1,0 +1,62 @@
+<?php
+require_once __DIR__ . '/core/config/config.php';
+require_once APP_BASE_PHYSICAL_PATH . '/core/config/conn.php';
+require_once APP_BASE_PHYSICAL_PATH . '/core/Model.php';
+require_once APP_BASE_PHYSICAL_PATH . '/app/model/InvitacionModel.php';
+require_once APP_BASE_PHYSICAL_PATH . '/app/model/RetoModel.php';
+require_once APP_BASE_PHYSICAL_PATH . '/app/model/RegistroAsistenciaModel.php';
+require_once APP_BASE_PHYSICAL_PATH . '/app/model/RegistroRetoModel.php';
+
+header('Content-Type: application/json');
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['exito' => false, 'mensaje' => 'Método no permitido.']);
+    exit;
+}
+
+$token = $_POST['token'] ?? '';
+$id_reto = (int)($_POST['id_reto'] ?? 0);
+$fruta = trim($_POST['fruta'] ?? '');
+$color = trim($_POST['color'] ?? '');
+$animal = trim($_POST['animal'] ?? '');
+
+$invitacionModel = new InvitacionModel();
+$retoModel = new RetoModel();
+$registroRetoModel = new RegistroRetoModel();
+$registroAsistenciaModel = new RegistroAsistenciaModel();
+
+$invitacion = $invitacionModel->obtenerPorToken($token);
+if (!$invitacion) {
+    echo json_encode(['exito' => false, 'mensaje' => 'Token inválido.']);
+    exit;
+}
+
+$reto = $retoModel->obtenerActivoPorEvento($invitacion->id_evento);
+if (!$reto || $reto->id != $id_reto) {
+    echo json_encode(['exito' => false, 'mensaje' => 'Reto fuera de tiempo.']);
+    exit;
+}
+
+if ($registroRetoModel->yaCompletado($reto->id, $invitacion->id)) {
+    echo json_encode(['exito' => false, 'mensaje' => 'Reto ya completado.']);
+    exit;
+}
+
+$partes = explode('-', $reto->codigo_actual);
+if (count($partes) === 3) {
+    list($frutaCor, $colorCor, $animalCor) = $partes;
+} else {
+    $frutaCor = $colorCor = $animalCor = '';
+}
+
+$codigoIngresado = $fruta . '-' . $color . '-' . $animal;
+$correcto = (strcasecmp($frutaCor, $fruta) === 0 &&
+             strcasecmp($colorCor, $color) === 0 &&
+             strcasecmp($animalCor, $animal) === 0) ? 1 : 0;
+$registroRetoModel->crear($reto->id, $invitacion->id, $codigoIngresado, $_SERVER['REMOTE_ADDR'] ?? '', $correcto);
+
+if ($correcto == 1 && !$registroAsistenciaModel->yaRegistrado($invitacion->id)) {
+    $registroAsistenciaModel->crear($invitacion->id, 'Reto ' . $reto->id);
+    $invitacionModel->marcarAsistenciaVerificada($invitacion->id);
+}
+
+echo json_encode(['exito' => $correcto == 1]);


### PR DESCRIPTION
## Summary
- style challenge items with consistent sizing
- add `validar_reto.php` for AJAX validation
- use new script from assistant page

## Testing
- `php -l validar_reto.php`
- `php -l get_codigo_reto.php`
- `php -l app/views/asistencia/espera_reto.php`


------
https://chatgpt.com/codex/tasks/task_e_688c17792440832ca99be5f7665609d8