### PR TITLE
Improve 3-FAV verification UI

### DIFF
--- a/app/views/asistencia/bienvenida.php
+++ b/app/views/asistencia/bienvenida.php
@@ -85,12 +85,14 @@ $invitacion = $datos['invitacion'];
 						<h6 class="mb-3">Detalles de tu Registro:</h6>
 						<ul class="list-unstyled">
 							<li><strong>Fecha y Hora:</strong> <?php echo date('d/m/Y h:i:s A', strtotime($invitacion->fecha_checkin)); ?></li>
-							<li class="mt-2"><strong>Clave Visual utilizada:</strong>
-								<div class="d-flex align-items-center mt-1 clave-visual-summary">
-									<img src="<?php echo URL_PATH; ?>core/img/clave_visual/<?php echo $invitacion->clave_visual_tipo . '/' . $invitacion->clave_visual_valor; ?>" alt="Imagen Clave">
-									<div class="color-box ms-2" style="background-color: <?php echo strtolower($invitacion->clave_texto); ?>"></div>
-								</div>
-							</li>
+                                                        <li class="mt-2"><strong>Clave Visual utilizada:</strong>
+                                                                <div class="d-flex align-items-center mt-1 clave-visual-summary">
+<?php list($frutaImg,$animalImg) = explode('|', $invitacion->clave_visual_valor); ?>
+                                                                        <img src="<?php echo URL_PATH; ?>core/img/clave_visual/frutas/<?php echo $frutaImg; ?>" alt="Fruta">
+                                                                        <img src="<?php echo URL_PATH; ?>core/img/clave_visual/animales/<?php echo $animalImg; ?>" alt="Animal" class="ms-2">
+                                                                        <div class="color-box ms-2" style="background-color: <?php echo strtolower($invitacion->clave_texto); ?>"></div>
+                                                                </div>
+                                                        </li>
 							<li class="mt-2"><strong>Token de Acceso:</strong> <small><code title="<?php echo $invitacion->token_acceso; ?>"><?php echo substr($invitacion->token_acceso, 0, 8) . '...' . substr($invitacion->token_acceso, -8); ?></code></small></li>
 						</ul>
 					</div>

--- a/app/views/asistencia/verificacion_clave_visual.php
+++ b/app/views/asistencia/verificacion_clave_visual.php
@@ -1,83 +1,83 @@
 <?php
 $invitacion = $datos['invitacion'];
-$opciones_imagenes = $datos['opciones_imagenes'];
+$opciones_frutas = $datos['opciones_frutas'];
 $opciones_colores = $datos['opciones_colores'];
+$opciones_animales = $datos['opciones_animales'];
 ?>
 <style>
-	.clave-option-img {
-		border: 4px solid transparent;
-		border-radius: 0.75rem;
-		transition: all 0.2s ease-in-out;
-		cursor: pointer;
-	}
-
-	.clave-option-img:hover {
-		transform: scale(1.05);
-		border-color: #0d6efd;
-	}
-
-	.clave-option-img.selected {
-		border-color: #0d6efd;
-		box-shadow: 0 0 15px rgba(13, 110, 253, 0.5);
-	}
-
-	/* CORRECCIÓN: Botones cuadrados y más pequeños */
-	.color-btn {
-		width: 50px;
-		height: 50px;
-		border: 4px solid transparent;
-		transition: all 0.2s ease-in-out;
-	}
-
-	.color-btn.selected {
-		border-color: #212529;
-		transform: scale(1.1);
-	}
+.opciones {
+  display: flex;
+  justify-content: center;
+  gap: 15px;
+  margin: 10px 0 20px;
+}
+.opciones img,
+.opciones button {
+  width: 80px;
+  height: 80px;
+  cursor: pointer;
+  border: 2px solid transparent;
+  border-radius: 5px;
+}
+.seleccionado {
+  border: 3px solid #2ecc71 !important;
+}
 </style>
 <div class="container container-main d-flex align-items-center">
-	<div class="w-100" style="max-width: 700px; margin: auto;">
-		<div class="text-center mb-4">
-			<h1 class="h2 mb-3">Verificación Final</h1>
-			<p class="lead text-muted">Para completar tu registro, selecciona la clave visual que hemos enviado a tu correo.</p>
-		</div>
-		<div class="card shadow-sm">
-			<div class="card-body p-4" x-data="{ selectedImage: '', selectedColor: '' }">
-				<form action="<?php echo URL_PATH; ?>asistencia/procesarClaveVisual" method="POST">
-					<input type="hidden" name="token_acceso" value="<?php echo $invitacion->token_acceso; ?>">
-					<input type="hidden" name="clave_imagen" x-model="selectedImage">
-					<input type="hidden" name="clave_color" x-model="selectedColor">
+  <div class="w-100" style="max-width: 700px; margin: auto;">
+    <div class="text-center mb-4">
+      <h1 class="h2 mb-3">Verificación Final</h1>
+      <p class="lead text-muted">Para completar tu registro, selecciona la combinación correcta.</p>
+    </div>
+    <div class="card shadow-sm">
+      <div class="card-body p-4">
+        <form action="<?php echo URL_PATH; ?>asistencia/procesarClaveVisual" method="POST" id="formClave">
+          <input type="hidden" name="token_acceso" value="<?php echo $invitacion->token_acceso; ?>">
+          <input type="hidden" name="clave_fruta" id="clave_fruta">
+          <input type="hidden" name="clave_color" id="clave_color">
+          <input type="hidden" name="clave_animal" id="clave_animal">
 
-					<h5 class="text-center">1. Selecciona la Imagen Correcta</h5>
-					<div class="row g-3 justify-content-center mb-4">
-						<?php foreach ($opciones_imagenes as $img): ?>
-							<div class="col-4 col-md-3">
-								<img src="<?php echo URL_PATH; ?>core/img/clave_visual/<?php echo $invitacion->clave_visual_tipo . '/' . $img; ?>"
-									class="img-fluid clave-option-img"
-									:class="{ 'selected': selectedImage === '<?php echo $img; ?>' }"
-									@click="selectedImage = '<?php echo $img; ?>'">
-							</div>
-						<?php endforeach; ?>
-					</div>
+          <div class="titulo-seccion">Selecciona la fruta que viste:</div>
+          <div class="opciones" id="frutas">
+<?php foreach ($opciones_frutas as $img): ?>
+            <img src="<?php echo URL_PATH; ?>core/img/clave_visual/frutas/<?php echo $img; ?>" data-valor="<?php echo $img; ?>" onclick="seleccionar(this, 'fruta')">
+<?php endforeach; ?>
+          </div>
 
-					<h5 class="text-center">2. Selecciona el Color Correcto</h5>
-					<div class="d-flex justify-content-center gap-3 mb-4">
-						<?php foreach ($opciones_colores as $color): ?>
-							<?php // CORRECCIÓN: Se elimina el 'rounded-circle' para que sea un botón cuadrado (pequeño) 
-							?>
-							<button type="button" class="btn color-btn"
-								style="background-color: <?php echo strtolower($color); ?>;"
-								:class="{ 'selected': selectedColor === '<?php echo $color; ?>' }"
-								@click="selectedColor = '<?php echo $color; ?>'"></button>
-						<?php endforeach; ?>
-					</div>
+          <div class="titulo-seccion">Selecciona el color que viste:</div>
+          <div class="opciones" id="colores">
+<?php foreach ($opciones_colores as $color): ?>
+            <button type="button" style="background:<?php echo strtolower($color); ?>;" data-valor="<?php echo $color; ?>" onclick="seleccionar(this, 'color')"></button>
+<?php endforeach; ?>
+          </div>
 
-					<div class="d-grid">
-						<button type="submit" class="btn btn-primary btn-lg" :disabled="!selectedImage || !selectedColor">
-							<i class="bi bi-check-circle-fill me-2"></i>Verificar Asistencia
-						</button>
-					</div>
-				</form>
-			</div>
-		</div>
-	</div>
+          <div class="titulo-seccion">Selecciona el animal que viste:</div>
+          <div class="opciones" id="animales">
+<?php foreach ($opciones_animales as $img): ?>
+            <img src="<?php echo URL_PATH; ?>core/img/clave_visual/animales/<?php echo $img; ?>" data-valor="<?php echo $img; ?>" onclick="seleccionar(this, 'animal')">
+<?php endforeach; ?>
+          </div>
+
+          <div class="d-grid">
+            <button type="submit" class="btn btn-primary btn-lg" id="confirmar" disabled>Confirmar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
 </div>
+<script>
+function seleccionar(el, grupo) {
+  const cont = document.getElementById(grupo + 's');
+  Array.from(cont.children).forEach(c => c.classList.remove('seleccionado'));
+  el.classList.add('seleccionado');
+  document.getElementById('clave_' + grupo).value = el.dataset.valor;
+  validarSeleccion();
+}
+function validarSeleccion() {
+  const f = document.getElementById('clave_fruta').value;
+  const c = document.getElementById('clave_color').value;
+  const a = document.getElementById('clave_animal').value;
+  document.getElementById('confirmar').disabled = !(f && c && a);
+}
+</script>


### PR DESCRIPTION
## Summary
- implement fruit/animal/color selection on verification screen
- store and validate fruit, animal and color in controller
- show chosen fruit, animal and color after check-in

## Testing
- `php -l app/controller/AsistenciaController.php`
- `php -l app/views/asistencia/verificacion_clave_visual.php`
- `php -l app/views/asistencia/bienvenida.php`


------
https://chatgpt.com/codex/tasks/task_e_688c30e02558832c884668fba1376c03