### PR TITLE
Fix dynamic challenge fetching on mobile

### DIFF
--- a/app/views/eventos/kiosko_virtual.php
+++ b/app/views/eventos/kiosko_virtual.php
@@ -239,7 +239,10 @@ $evento = $datos['evento'];
 
                         async function actualizarToken() {
                                 try {
-                                        const response = await fetch('<?php echo URL_PATH; ?>get_codigo_reto.php?id_evento=<?php echo $evento->id; ?>');
+                                const url = 'https://generandocodigo.com/vocatorid/get_codigo_reto.php?id_evento=<?php echo $evento->id; ?>&ts=' + Date.now();
+                                const response = await fetch(url, {
+                                        headers: { 'Cache-Control': 'no-cache' }
+                                });
                                         if (!response.ok) throw new Error('Error de red');
 
                                         const data = await response.json();

--- a/get_codigo_reto.php
+++ b/get_codigo_reto.php
@@ -6,7 +6,9 @@ require_once APP_BASE_PHYSICAL_PATH . '/app/model/RetoModel.php';
 require_once APP_BASE_PHYSICAL_PATH . '/app/controller/AsistenciaController.php';
 require_once APP_BASE_PHYSICAL_PATH . '/core/config/recursos.php';
 
-header('Content-Type: application/json');
+// Cabeceras para evitar problemas CORS y de codificación
+header('Access-Control-Allow-Origin: *');
+header('Content-Type: application/json; charset=UTF-8');
 
 $id_evento = isset($_GET['id_evento']) ? (int)$_GET['id_evento'] : 0;
 


### PR DESCRIPTION
## Summary
- add CORS headers in `get_codigo_reto.php`
- request `get_codigo_reto.php` with absolute URL and disable cache in kiosk view

## Testing
- `php -l get_codigo_reto.php`
- `php -l app/views/eventos/kiosko_virtual.php`


------
https://chatgpt.com/codex/tasks/task_e_688d2d2587d0832c86fb1ecf6d331b90