### PR TITLE
feat: show six options per category in visual key

### DIFF
--- a/app/controller/AsistenciaController.php
+++ b/app/controller/AsistenciaController.php
@@ -180,13 +180,13 @@ class AsistenciaController extends Controller
 
                         $opciones_frutas = array_map(
                                 fn($n) => URL_PATH . 'core/img/clave_visual/frutas/' . $n . '.jpg',
-                                generarOpcionesLista($listaFrutas, $datos['fruta'])
+                                generarOpcionesLista($listaFrutas, $datos['fruta'], 6)
                         );
                         $opciones_animales = array_map(
                                 fn($n) => URL_PATH . 'core/img/clave_visual/animales/' . $n . '.jpg',
-                                generarOpcionesLista($listaAnimales, $datos['animal'])
+                                generarOpcionesLista($listaAnimales, $datos['animal'], 6)
                         );
-                        $opciones_colores = generarOpcionesLista($listaColores, $datos['color_hex']);
+                        $opciones_colores = generarOpcionesLista($listaColores, $datos['color_hex'], 6);
 
                         echo json_encode([
                                 'exito' => true,

--- a/app/views/asistencia/espera_reto.php
+++ b/app/views/asistencia/espera_reto.php
@@ -63,6 +63,10 @@ shuffle($frutas);
 shuffle($animales);
 shuffle($colores);
 
+$frutas  = array_slice($frutas, 0, 6);
+$animales = array_slice($animales, 0, 6);
+$colores = array_slice($colores, 0, 6);
+
 header('Content-Type: text/html; charset=utf-8');
 ?>
 <style>

--- a/core/config/recursos.php
+++ b/core/config/recursos.php
@@ -168,8 +168,12 @@ function datosDesdeCodigoVisual($codigo, $colores)
 /**
  * Genera un listado de opciones que incluye la respuesta correcta
  * y un número de distractores aleatorios.
+ *
+ * @param array $lista Lista total de elementos disponibles.
+ * @param mixed $correcta Elemento que debe estar presente en el listado.
+ * @param int $cantidad Cantidad total de opciones a generar (incluye la correcta). Por defecto 6.
  */
-function generarOpcionesLista(array $lista, $correcta, $cantidad = 5)
+function generarOpcionesLista(array $lista, $correcta, $cantidad = 6)
 {
         $opciones = [$correcta];
         $resto = array_values(array_diff($lista, [$correcta]));


### PR DESCRIPTION
## Summary
- Expand visual key challenge to present six options for fruits, animals, and colors
- Default option generator now returns six elements
- Limit fallback option lists to six items per category

## Testing
- `php -l app/controller/AsistenciaController.php`
- `php -l core/config/recursos.php`
- `php -l app/views/asistencia/espera_reto.php`


------
https://chatgpt.com/codex/tasks/task_e_6893f76764b4832c92f6208cfa9bab93