### PR TITLE
Add feedback for dynamic key validation

### DIFF
--- a/app/controller/AsistenciaController.php
+++ b/app/controller/AsistenciaController.php
@@ -257,7 +257,17 @@ class AsistenciaController extends Controller
                         $this->invitacionModel->marcarAsistenciaVerificada($invitacion->id);
                 }
 
-                echo json_encode(['exito' => $correcto == 1]);
+                if ($correcto == 1) {
+                        echo json_encode([
+                                'exito'   => true,
+                                'mensaje' => '¡Asistencia registrada con éxito!'
+                        ], JSON_UNESCAPED_UNICODE);
+                } else {
+                        echo json_encode([
+                                'exito'   => false,
+                                'mensaje' => 'La combinación seleccionada no coincide con la clave dinámica.'
+                        ], JSON_UNESCAPED_UNICODE);
+                }
         }
 
 	public function registroAnonimo($id_evento = 0)

--- a/app/views/asistencia/espera_reto.php
+++ b/app/views/asistencia/espera_reto.php
@@ -158,6 +158,20 @@ body {
 .boton-verificar:hover {
   background: #0056b3;
 }
+
+#mensaje .error {
+  background: #f8d7da;
+  color: #842029;
+  padding: 12px;
+  border-radius: 5px;
+}
+
+#mensaje .exito {
+  background: #d1e7dd;
+  color: #0f5132;
+  padding: 12px;
+  border-radius: 5px;
+}
 </style>
 
 <div class="container container-main d-flex align-items-center">
@@ -217,3 +231,31 @@ body {
     <div id="mensaje" class="mt-3"></div>
   </div>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('form');
+  const mensajeDiv = document.getElementById('mensaje');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    mensajeDiv.innerHTML = '';
+    const formData = new FormData(form);
+    try {
+      const respuesta = await fetch(form.action, {
+        method: 'POST',
+        body: formData
+      });
+      const datos = await respuesta.json();
+      if (datos.exito) {
+        mensajeDiv.innerHTML = '<div class="exito">✅ ' + (datos.mensaje || 'Asistencia registrada correctamente.') + '</div>';
+        form.reset();
+      } else {
+        mensajeDiv.innerHTML = '<div class="error">❌ ' + (datos.mensaje || 'La combinación seleccionada no es correcta.') + '</div>';
+      }
+    } catch (err) {
+      mensajeDiv.innerHTML = '<div class="error">❌ Error al procesar la solicitud.</div>';
+    }
+  });
+});
+</script>

--- a/validar_reto.php
+++ b/validar_reto.php
@@ -59,4 +59,14 @@ if ($correcto == 1 && !$registroAsistenciaModel->yaRegistrado($invitacion->id)) 
     $invitacionModel->marcarAsistenciaVerificada($invitacion->id);
 }
 
-echo json_encode(['exito' => $correcto == 1]);
+if ($correcto == 1) {
+    echo json_encode([
+        'exito'   => true,
+        'mensaje' => '¡Asistencia registrada con éxito!'
+    ], JSON_UNESCAPED_UNICODE);
+} else {
+    echo json_encode([
+        'exito'   => false,
+        'mensaje' => 'La combinación seleccionada no coincide con la clave dinámica.'
+    ], JSON_UNESCAPED_UNICODE);
+}


### PR DESCRIPTION
## Summary
- Send a descriptive message when validating the dynamic key through both controller and standalone script.
- Handle validation response via AJAX in the attendance verification view, showing success or error feedback.

## Testing
- `php -l validar_reto.php`
- `php -l app/controller/AsistenciaController.php`
- `php -l app/views/asistencia/espera_reto.php`


------
https://chatgpt.com/codex/tasks/task_e_6893f8f7feb0832c9f781c56d2002378