### PR TITLE
Trim dynamic key parts and add debug comparison

### DIFF
--- a/app/views/asistencia/espera_reto.php
+++ b/app/views/asistencia/espera_reto.php
@@ -247,6 +247,10 @@ document.addEventListener('DOMContentLoaded', () => {
         body: formData
       });
       const datos = await respuesta.json();
+      // DEBUG INICIO
+      console.log('Clave seleccionada:', datos.debug_seleccionada);
+      console.log('Clave correcta:', datos.debug_correcta);
+      // DEBUG FIN
       if (datos.exito) {
         mensajeDiv.innerHTML = '<div class="exito">✅ ' + (datos.mensaje || 'Asistencia registrada correctamente.') + '</div>';
         form.reset();

--- a/validar_reto.php
+++ b/validar_reto.php
@@ -43,12 +43,28 @@ if ($registroRetoModel->yaCompletado($reto->id, $invitacion->id)) {
 
 $partes = explode('-', $reto->codigo_actual);
 if (count($partes) === 3) {
-    list($frutaCor, $colorCor, $animalCor) = $partes;
+    list($frutaCor, $colorCor, $animalCor) = array_map('trim', $partes);
 } else {
     $frutaCor = $colorCor = $animalCor = '';
 }
 
 $codigoIngresado = $fruta . '-' . $color . '-' . $animal;
+
+// DEBUG INICIO
+$claveSeleccionada = [
+    'fruta' => $fruta,
+    'color' => $color,
+    'animal' => $animal
+];
+$claveCorrecta = [
+    'fruta' => $frutaCor,
+    'color' => $colorCor,
+    'animal' => $animalCor
+];
+error_log('Clave seleccionada: ' . json_encode($claveSeleccionada));
+error_log('Clave correcta: ' . json_encode($claveCorrecta));
+// DEBUG FIN
+
 $correcto = (strcasecmp($frutaCor, $fruta) === 0 &&
              strcasecmp($colorCor, $color) === 0 &&
              strcasecmp($animalCor, $animal) === 0) ? 1 : 0;
@@ -59,14 +75,13 @@ if ($correcto == 1 && !$registroAsistenciaModel->yaRegistrado($invitacion->id)) 
     $invitacionModel->marcarAsistenciaVerificada($invitacion->id);
 }
 
-if ($correcto == 1) {
-    echo json_encode([
-        'exito'   => true,
-        'mensaje' => '¡Asistencia registrada con éxito!'
-    ], JSON_UNESCAPED_UNICODE);
-} else {
-    echo json_encode([
-        'exito'   => false,
-        'mensaje' => 'La combinación seleccionada no coincide con la clave dinámica.'
-    ], JSON_UNESCAPED_UNICODE);
-}
+$respuesta = ($correcto == 1)
+    ? ['exito' => true,  'mensaje' => '¡Asistencia registrada con éxito!']
+    : ['exito' => false, 'mensaje' => 'La combinación seleccionada no coincide con la clave dinámica.'];
+
+// DEBUG INICIO
+$respuesta['debug_seleccionada'] = $claveSeleccionada;
+$respuesta['debug_correcta'] = $claveCorrecta;
+// DEBUG FIN
+
+echo json_encode($respuesta, JSON_UNESCAPED_UNICODE);


### PR DESCRIPTION
## Summary
- Ensure dynamic key parts are trimmed before validation
- Log selected and correct dynamic keys as JSON for debugging
- Surface debug data in client and console.log it for inspection

## Testing
- `php -l validar_reto.php`
- `php -l app/views/asistencia/espera_reto.php`


------
https://chatgpt.com/codex/tasks/task_e_6893fce1426c832cbf89df61d4545df1