### PR TITLE
Validación de reto vía AsistenciaController

### DIFF
--- a/app/views/asistencia/espera_reto.php
+++ b/app/views/asistencia/espera_reto.php
@@ -186,7 +186,7 @@ body {
       <p>Selecciona los elementos que viste en la pantalla compartida del evento.</p>
     </div>
 
-    <form method="POST" action="<?= URL_PATH; ?>validar_reto.php">
+    <form method="POST" action="<?= URL_PATH; ?>asistencia/validarReto">
       <input type="hidden" name="token" value="<?= $invitacion->token_acceso; ?>">
       <input type="hidden" name="id_reto" value="<?= $idReto; ?>">
 
@@ -247,10 +247,6 @@ document.addEventListener('DOMContentLoaded', () => {
         body: formData
       });
       const datos = await respuesta.json();
-      // DEBUG INICIO
-      console.log('Clave seleccionada:', datos.debug_seleccionada);
-      console.log('Clave correcta:', datos.debug_correcta);
-      // DEBUG FIN
       if (datos.exito) {
         mensajeDiv.innerHTML = '<div class="exito">✅ ' + (datos.mensaje || 'Asistencia registrada correctamente.') + '</div>';
         form.reset();

--- a/index.php
+++ b/index.php
@@ -39,9 +39,10 @@ $rutas_publicas = [
 	// Controlador 'asistencia'
         'asistencia/bienvenida',
         'asistencia/inicio',
-	'asistencia/registroAnonimo',
-	'asistencia/procesarRegistroAnonimo',
-	'asistencia/procesarQrPersonal', // API para kiosco físico
+        'asistencia/registroAnonimo',
+        'asistencia/procesarRegistroAnonimo',
+        'asistencia/procesarQrPersonal', // API para kiosco físico
+        'asistencia/validarReto',
 
 	// Controlador 'invitacion'
 	'invitacion/responder'


### PR DESCRIPTION
## Summary
- Permitir acceso público al método `validarReto` del controlador de asistencia.
- Enviar la combinación seleccionada al controlador de asistencia y mostrar mensajes de éxito o error según la validación.

## Testing
- `php -l index.php`
- `php -l app/views/asistencia/espera_reto.php`


------
https://chatgpt.com/codex/tasks/task_e_6894017acab0832cb331ee4398d11dce