### PR TITLE
Add console debug for selected combination

### DIFF
--- a/app/controller/AsistenciaController.php
+++ b/app/controller/AsistenciaController.php
@@ -249,6 +249,8 @@ class AsistenciaController extends Controller
                 }
 
                 $codigoIngresado = $fruta . '-' . $color . '-' . $animal;
+                echo "Combinación seleccionada por el usuario: $codigoIngresado\n";
+                echo "Clave correcta: " . $reto->codigo_actual . "\n";
                 $correcto = (strcasecmp($frutaCor, $fruta) === 0 && strcasecmp($colorCor, $color) === 0 && strcasecmp($animalCor, $animal) === 0) ? 1 : 0;
                 $this->registroRetoModel->crear($reto->id, $invitacion->id, $codigoIngresado, $_SERVER['REMOTE_ADDR'] ?? '', $correcto);
 

--- a/validar_reto.php
+++ b/validar_reto.php
@@ -61,8 +61,8 @@ $claveCorrecta = [
     'color' => $colorCor,
     'animal' => $animalCor
 ];
-error_log('Clave seleccionada: ' . json_encode($claveSeleccionada));
-error_log('Clave correcta: ' . json_encode($claveCorrecta));
+    echo 'Clave seleccionada: ' . json_encode($claveSeleccionada) . PHP_EOL;
+    echo 'Clave correcta: ' . json_encode($claveCorrecta) . PHP_EOL;
 // DEBUG FIN
 
 $correcto = (strcasecmp($frutaCor, $fruta) === 0 &&


### PR DESCRIPTION
## Summary
- output user-selected combination and correct key during reto validation

## Testing
- `php -l app/controller/AsistenciaController.php`


------
https://chatgpt.com/codex/tasks/task_e_689403810984832c9f1078857af76761