### PR TITLE
Add console debug for selected combination

### DIFF
--- a/app/controller/AsistenciaController.php
+++ b/app/controller/AsistenciaController.php
@@ -243,12 +243,27 @@ class AsistenciaController extends Controller
 
                 $partes = explode('-', $reto->codigo_actual);
                 if (count($partes) === 3) {
-                        list($frutaCor, $colorCor, $animalCor) = $partes;
+                        list($frutaCor, $colorCor, $animalCor) = array_map('trim', $partes);
                 } else {
                         $frutaCor = $colorCor = $animalCor = '';
                 }
 
                 $codigoIngresado = $fruta . '-' . $color . '-' . $animal;
+
+                $claveSeleccionada = [
+                        'fruta' => $fruta,
+                        'color' => $color,
+                        'animal' => $animal
+                ];
+                $claveCorrecta = [
+                        'fruta' => $frutaCor,
+                        'color' => $colorCor,
+                        'animal' => $animalCor
+                ];
+
+                echo 'Clave seleccionada: ' . json_encode($claveSeleccionada) . PHP_EOL;
+                echo 'Clave correcta: ' . json_encode($claveCorrecta) . PHP_EOL;
+
                 $correcto = (strcasecmp($frutaCor, $fruta) === 0 && strcasecmp($colorCor, $color) === 0 && strcasecmp($animalCor, $animal) === 0) ? 1 : 0;
                 $this->registroRetoModel->crear($reto->id, $invitacion->id, $codigoIngresado, $_SERVER['REMOTE_ADDR'] ?? '', $correcto);
 

--- a/validar_reto.php
+++ b/validar_reto.php
@@ -61,8 +61,8 @@ $claveCorrecta = [
     'color' => $colorCor,
     'animal' => $animalCor
 ];
-error_log('Clave seleccionada: ' . json_encode($claveSeleccionada));
-error_log('Clave correcta: ' . json_encode($claveCorrecta));
+    echo 'Clave seleccionada: ' . json_encode($claveSeleccionada) . PHP_EOL;
+    echo 'Clave correcta: ' . json_encode($claveCorrecta) . PHP_EOL;
 // DEBUG FIN
 
 $correcto = (strcasecmp($frutaCor, $fruta) === 0 &&


### PR DESCRIPTION
## Summary
- trim stored reto key parts to avoid whitespace mismatches
- log selected and correct combinations for debugging during reto validation

## Testing
- `php -l app/controller/AsistenciaController.php`
- `php -l validar_reto.php`


------
https://chatgpt.com/codex/tasks/task_e_689403810984832c9f1078857af76761