### PR TITLE
Ensure challenge code persists without timestamp column

### DIFF
--- a/app/controller/AsistenciaController.php
+++ b/app/controller/AsistenciaController.php
@@ -160,7 +160,10 @@ class AsistenciaController extends Controller
                                 $codigo = $datos['codigo'];
                                 unset($datos['codigo']);
                                 if (method_exists($this->retoModel, 'actualizarCodigoYFecha')) {
-                                        $this->retoModel->actualizarCodigoYFecha($reto->id, $codigo);
+                                        $actualizado = $this->retoModel->actualizarCodigoYFecha($reto->id, $codigo);
+                                        if (!$actualizado) {
+                                                $this->retoModel->actualizarCodigo($reto->id, $codigo);
+                                        }
                                 } else {
                                         $this->retoModel->actualizarCodigo($reto->id, $codigo);
                                 }

--- a/get_codigo_reto.php
+++ b/get_codigo_reto.php
@@ -26,7 +26,10 @@ if (empty($reto->codigo_actual) || ($ahora - $timestamp) >= 40) {
     $codigo = $datos['codigo'];
     unset($datos['codigo']);
     if (method_exists($retoModel, 'actualizarCodigoYFecha')) {
-        $retoModel->actualizarCodigoYFecha($reto->id, $codigo);
+        $actualizado = $retoModel->actualizarCodigoYFecha($reto->id, $codigo);
+        if (!$actualizado) {
+            $retoModel->actualizarCodigo($reto->id, $codigo);
+        }
     } else {
         $retoModel->actualizarCodigo($reto->id, $codigo);
     }


### PR DESCRIPTION
## Summary
- Ensure challenge code updates fallback to `actualizarCodigo` when timestamp column update fails
- Mirror fallback in controller and standalone retrieval script so kiosks always send a stored code

## Testing
- `php -l get_codigo_reto.php`
- `php -l app/controller/AsistenciaController.php`


------
https://chatgpt.com/codex/tasks/task_e_68940b44b0ec832c86ff50bb603c7813