### PR TITLE
Validar fechas para creación de retos de asistencia

### DIFF
--- a/app/controller/EventoController.php
+++ b/app/controller/EventoController.php
@@ -344,8 +344,8 @@ class EventoController extends Controller
                         return;
                 }
 
-                if (in_array($evento->estado, ['Finalizado', 'Cancelado'])) {
-                        echo json_encode(['exito' => false, 'mensaje' => 'El evento se encuentra ' . strtolower($evento->estado) . '.']);
+                if ($evento->estado !== 'Publicado' || (property_exists($evento, 'activo') && !$evento->activo)) {
+                        echo json_encode(['exito' => false, 'mensaje' => 'El evento debe estar publicado y activo.']);
                         return;
                 }
 
@@ -361,12 +361,18 @@ class EventoController extends Controller
                         return;
                 }
 
-                $fecha_evento = new DateTime($evento->fecha_evento);
-                $inicio_valido = (clone $fecha_evento)->modify('-8 days')->setTime(0, 0, 0);
-                $fin_valido = (clone $fecha_evento)->setTime(23, 59, 59);
+                $fin_evento = new DateTime($evento->fecha_evento);
+                $fin_evento->setTime(23, 59, 59);
+                $inicio_valido = (clone $fin_evento)->modify('-10 days');
 
-                if ($inicio < $inicio_valido || $fin > $fin_valido) {
-                        echo json_encode(['exito' => false, 'mensaje' => 'La hora de inicio y fin deben estar dentro del rango permitido.']);
+                $ahora = new DateTime();
+                if ($ahora < $inicio_valido || $ahora > $fin_evento) {
+                        echo json_encode(['exito' => false, 'mensaje' => 'No es permitida la creación del nuevo reto porque no está en las fechas establecidas.']);
+                        return;
+                }
+
+                if ($inicio < $inicio_valido || $fin > $fin_evento) {
+                        echo json_encode(['exito' => false, 'mensaje' => 'No es permitida la creación del nuevo reto porque no está en las fechas establecidas.']);
                         return;
                 }
 


### PR DESCRIPTION
## Summary
- Rechaza creación de retos si el evento no está publicado y activo
- Restringe fecha de creación y rango del reto a los 10 días previos al cierre del evento

## Testing
- `php -l app/controller/EventoController.php`

------
https://chatgpt.com/codex/tasks/task_e_68968a96ab9c832ca4f04dfc61cc29db