### PR TITLE
Validar fechas para creación de retos de asistencia

### DIFF
--- a/app/controller/EventoController.php
+++ b/app/controller/EventoController.php
@@ -344,8 +344,8 @@ class EventoController extends Controller
                         return;
                 }
 
-                if (in_array($evento->estado, ['Finalizado', 'Cancelado'])) {
-                        echo json_encode(['exito' => false, 'mensaje' => 'El evento se encuentra ' . strtolower($evento->estado) . '.']);
+                if ($evento->estado !== 'Publicado' || (property_exists($evento, 'activo') && !$evento->activo)) {
+                        echo json_encode(['exito' => false, 'mensaje' => 'El evento debe estar publicado y activo.']);
                         return;
                 }
 
@@ -361,12 +361,18 @@ class EventoController extends Controller
                         return;
                 }
 
-                $fecha_evento = new DateTime($evento->fecha_evento);
-                $inicio_valido = (clone $fecha_evento)->modify('-8 days')->setTime(0, 0, 0);
-                $fin_valido = (clone $fecha_evento)->setTime(23, 59, 59);
+                $fin_evento = new DateTime($evento->fecha_evento);
+                $fin_evento->setTime(23, 59, 59);
+                $inicio_valido = (clone $fin_evento)->modify('-10 days');
 
-                if ($inicio < $inicio_valido || $fin > $fin_valido) {
-                        echo json_encode(['exito' => false, 'mensaje' => 'La hora de inicio y fin deben estar dentro del rango permitido.']);
+                $ahora = new DateTime();
+                if ($ahora < $inicio_valido || $ahora > $fin_evento) {
+                        echo json_encode(['exito' => false, 'mensaje' => 'No es permitida la creación del nuevo reto porque no está en las fechas establecidas.']);
+                        return;
+                }
+
+                if ($inicio < $inicio_valido || $fin > $fin_evento) {
+                        echo json_encode(['exito' => false, 'mensaje' => 'No es permitida la creación del nuevo reto porque no está en las fechas establecidas.']);
                         return;
                 }
 

--- a/app/views/eventos/dashboard.php
+++ b/app/views/eventos/dashboard.php
@@ -4,6 +4,7 @@ $evento = $datos['evento'];
 ?>
 <div class="container-fluid px-md-4 py-4">
     <h1 class="h3 mb-4">Gestión de Retos de Asistencia - <?php echo htmlspecialchars($evento->nombre_evento); ?></h1>
+    <div id="alert-container"></div>
 
     <form id="form-reto" class="row g-2 mb-4">
         <div class="col-md-4">

--- a/app/views/eventos/gestionar.php
+++ b/app/views/eventos/gestionar.php
@@ -436,6 +436,7 @@ $porcentaje_eficiencia = ($total_invitados > 0) ? ($total_registrados / $total_i
                <div class="tab-pane fade" id="retos" role="tabpanel" aria-labelledby="retos-tab">
                        <div class="card shadow-sm mb-4">
                                <div class="card-body">
+                                       <div id="alert-container"></div>
                                        <form id="form-reto" class="row g-2 mb-3">
                                                <div class="col-md-4">
                                                        <input type="text" name="descripcion" class="form-control" placeholder="Descripción del Reto" required>

--- a/core/customassets/js/retos_admin.js
+++ b/core/customassets/js/retos_admin.js
@@ -1,5 +1,14 @@
 // Gestion dinámica de retos para el dashboard del organizador
 
+function mostrarAlerta(mensaje, tipo = 'danger'){
+    const cont = document.getElementById('alert-container');
+    if(!cont){
+        alert(mensaje);
+        return;
+    }
+    cont.innerHTML = `<div class="alert alert-${tipo} alert-dismissible fade show text-center" role="alert">${mensaje}<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>`;
+}
+
 async function cargarRetos(){
     const res = await fetch(`${URL_BASE}evento/estadoRetos/${ID_EVENTO}`);
     const data = await res.json();
@@ -25,10 +34,10 @@ async function crearReto(ev){
     const data = await res.json();
     if(data.exito){
         form.reset();
-        alert('Reto creado correctamente');
+        mostrarAlerta('Reto creado correctamente', 'success');
         cargarRetos();
     }else{
-        alert('Error al crear reto');
+        mostrarAlerta(data.mensaje || 'Error al crear reto', 'danger');
     }
 }
 


### PR DESCRIPTION
## Summary
- Rechaza creación de retos si el evento no está publicado y activo
- Restringe fecha de creación y rango del reto a los 10 días previos al cierre del evento
- Muestra mensajes de éxito o error mediante alertas visibles al crear retos

## Testing
- `php -l app/controller/EventoController.php`
- `php -l app/views/eventos/dashboard.php`
- `php -l app/views/eventos/gestionar.php`


------
https://chatgpt.com/codex/tasks/task_e_68968a96ab9c832ca4f04dfc61cc29db