### PR TITLE
Validar fechas para creación de retos de asistencia

### DIFF
--- a/app/controller/EventoController.php
+++ b/app/controller/EventoController.php
@@ -245,9 +245,25 @@ class EventoController extends Controller
                 if (!$evento) {
                         die('Este evento no existe.');
                 }
+
+                $mensaje = '';
+
+                if ($evento->estado !== 'Publicado' || (property_exists($evento, 'activo') && !$evento->activo)) {
+                        $mensaje = 'El evento debe estar publicado y activo.';
+                } else {
+                        $fin_evento = new DateTime($evento->fecha_evento);
+                        $fin_evento->setTime(23, 59, 59);
+                        $inicio_valido = (clone $fin_evento)->modify('-10 days');
+                        $ahora = new DateTime();
+                        if ($ahora < $inicio_valido || $ahora > $fin_evento) {
+                                $mensaje = 'No es permitida la apertura del kiosko virtual porque no está en las fechas establecidas.';
+                        }
+                }
+
                 $datos = [
                         'titulo' => 'Kiosko Virtual - ' . $evento->nombre_evento,
-                        'evento' => $evento
+                        'evento' => $evento,
+                        'mensaje_alerta' => $mensaje
                 ];
                 extract($datos);
                 require_once APP_BASE_PHYSICAL_PATH . '/app/views/eventos/kiosko_virtual.php';
@@ -344,8 +360,8 @@ class EventoController extends Controller
                         return;
                 }
 
-                if (in_array($evento->estado, ['Finalizado', 'Cancelado'])) {
-                        echo json_encode(['exito' => false, 'mensaje' => 'El evento se encuentra ' . strtolower($evento->estado) . '.']);
+                if ($evento->estado !== 'Publicado' || (property_exists($evento, 'activo') && !$evento->activo)) {
+                        echo json_encode(['exito' => false, 'mensaje' => 'El evento debe estar publicado y activo.']);
                         return;
                 }
 
@@ -361,12 +377,18 @@ class EventoController extends Controller
                         return;
                 }
 
-                $fecha_evento = new DateTime($evento->fecha_evento);
-                $inicio_valido = (clone $fecha_evento)->modify('-8 days')->setTime(0, 0, 0);
-                $fin_valido = (clone $fecha_evento)->setTime(23, 59, 59);
+                $fin_evento = new DateTime($evento->fecha_evento);
+                $fin_evento->setTime(23, 59, 59);
+                $inicio_valido = (clone $fin_evento)->modify('-10 days');
 
-                if ($inicio < $inicio_valido || $fin > $fin_valido) {
-                        echo json_encode(['exito' => false, 'mensaje' => 'La hora de inicio y fin deben estar dentro del rango permitido.']);
+                $ahora = new DateTime();
+                if ($ahora < $inicio_valido || $ahora > $fin_evento) {
+                        echo json_encode(['exito' => false, 'mensaje' => 'No es permitida la creación del nuevo reto porque no está en las fechas establecidas.']);
+                        return;
+                }
+
+                if ($inicio < $inicio_valido || $fin > $fin_evento) {
+                        echo json_encode(['exito' => false, 'mensaje' => 'No es permitida la creación del nuevo reto porque no está en las fechas establecidas.']);
                         return;
                 }
 

--- a/app/views/eventos/dashboard.php
+++ b/app/views/eventos/dashboard.php
@@ -4,6 +4,7 @@ $evento = $datos['evento'];
 ?>
 <div class="container-fluid px-md-4 py-4">
     <h1 class="h3 mb-4">Gestión de Retos de Asistencia - <?php echo htmlspecialchars($evento->nombre_evento); ?></h1>
+    <div id="alert-container"></div>
 
     <form id="form-reto" class="row g-2 mb-4">
         <div class="col-md-4">

--- a/app/views/eventos/gestionar.php
+++ b/app/views/eventos/gestionar.php
@@ -436,6 +436,7 @@ $porcentaje_eficiencia = ($total_invitados > 0) ? ($total_registrados / $total_i
                <div class="tab-pane fade" id="retos" role="tabpanel" aria-labelledby="retos-tab">
                        <div class="card shadow-sm mb-4">
                                <div class="card-body">
+                                       <div id="alert-container"></div>
                                        <form id="form-reto" class="row g-2 mb-3">
                                                <div class="col-md-4">
                                                        <input type="text" name="descripcion" class="form-control" placeholder="Descripción del Reto" required>

--- a/app/views/eventos/kiosko_virtual.php
+++ b/app/views/eventos/kiosko_virtual.php
@@ -1,6 +1,7 @@
 <?php
 // El header.php se carga automáticamente desde el controlador.
 $evento = $datos['evento'];
+$mensaje_alerta = $datos['mensaje_alerta'] ?? '';
 
 $api_url  = URL_PATH . 'get_codigo_reto.php?id_evento=' . $evento->id;
 $token_data = @json_decode(@file_get_contents($api_url), true) ?: [];
@@ -32,6 +33,7 @@ $tiempo_restante = isset($token_data['tiempo_restante']) ? (int)$token_data['tie
 <html lang="es">
 <head>
     <meta charset="utf-8">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Kiosko Virtual</title>
     <style>
@@ -123,6 +125,8 @@ body {
 <body>
 <div class="kiosko-wrapper" id="fondo-dinamico">
   <div class="kiosko-card">
+    <div id="alert-container"></div>
+    <?php if (empty($mensaje_alerta)): ?>
     <h1 class="titulo-kiosko">🔹 Clave Dinámica del Reto Actual 🔹</h1>
 
     <div class="clave-visual">
@@ -135,9 +139,11 @@ body {
       <div id="barra-progreso"></div>
       <span id="contador"></span>
     </div>
+    <?php endif; ?>
   </div>
 </div>
 
+<?php if (empty($mensaje_alerta)): ?>
 <div id="clave-data"
      data-fruta-nombre="<?= htmlspecialchars($fruta['nombre'], ENT_QUOTES, 'UTF-8') ?>"
      data-fruta-url="<?= htmlspecialchars($fruta['url'], ENT_QUOTES, 'UTF-8') ?>"
@@ -269,5 +275,23 @@ document.addEventListener('DOMContentLoaded', () => {
   }, 1000);
 });
 </script>
+<?php else: ?>
+<script>
+function mostrarAlerta(mensaje, tipo = 'danger'){
+  const cont = document.getElementById('alert-container');
+  if(!cont){
+    alert(mensaje);
+    return;
+  }
+  cont.innerHTML = `<div class="alert alert-${tipo} alert-dismissible fade show text-center" role="alert">${mensaje}<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>`;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  mostrarAlerta(<?= json_encode($mensaje_alerta) ?>);
+});
+</script>
+<?php endif; ?>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>
+

--- a/core/customassets/js/retos_admin.js
+++ b/core/customassets/js/retos_admin.js
@@ -1,5 +1,14 @@
 // Gestion dinámica de retos para el dashboard del organizador
 
+function mostrarAlerta(mensaje, tipo = 'danger'){
+    const cont = document.getElementById('alert-container');
+    if(!cont){
+        alert(mensaje);
+        return;
+    }
+    cont.innerHTML = `<div class="alert alert-${tipo} alert-dismissible fade show text-center" role="alert">${mensaje}<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>`;
+}
+
 async function cargarRetos(){
     const res = await fetch(`${URL_BASE}evento/estadoRetos/${ID_EVENTO}`);
     const data = await res.json();
@@ -25,10 +34,10 @@ async function crearReto(ev){
     const data = await res.json();
     if(data.exito){
         form.reset();
-        alert('Reto creado correctamente');
+        mostrarAlerta('Reto creado correctamente', 'success');
         cargarRetos();
     }else{
-        alert('Error al crear reto');
+        mostrarAlerta(data.mensaje || 'Error al crear reto', 'danger');
     }
 }
 


### PR DESCRIPTION
## Summary
- Rechaza creación de retos si el evento no está publicado y activo
- Restringe fecha de creación y rango del reto a los 10 días previos al cierre del evento
- Muestra mensajes de éxito o error mediante alertas visibles
- Impide abrir el kiosko virtual fuera del periodo permitido y notifica al asistente con una alerta UI

## Testing
- `php -l app/controller/EventoController.php`
- `php -l app/views/eventos/kiosko_virtual.php`
- `php -l app/views/eventos/dashboard.php`
- `php -l app/views/eventos/gestionar.php`


------
https://chatgpt.com/codex/tasks/task_e_68968a96ab9c832ca4f04dfc61cc29db